### PR TITLE
Updated libigl version to fix error on macOS with CMake 3.19.0

### DIFF
--- a/apps/bc_setter.cpp
+++ b/apps/bc_setter.cpp
@@ -466,14 +466,14 @@ int main(int argc, char **argv)
 
 				if(vals.bc_value[i-1] == 0)
 				{
-					ImGui::InputFloat(xlabel.c_str(), &vals.vals[i-1][0], 0, 0, 3);
+					ImGui::InputFloat(xlabel.c_str(), &vals.vals[i-1][0], 0, 0, "%.3f");
 
 					if(vector_problem){
 						ImGui::SameLine();
-						ImGui::InputFloat(ylabel.c_str(), &vals.vals[i-1][1], 0, 0, 3);
+						ImGui::InputFloat(ylabel.c_str(), &vals.vals[i-1][1], 0, 0, "%.3f");
 						if(is_volume){
 							ImGui::SameLine();
-							ImGui::InputFloat(zlabel.c_str(), &vals.vals[i-1][2], 0, 0, 3);
+							ImGui::InputFloat(zlabel.c_str(), &vals.vals[i-1][2], 0, 0, "%.3f");
 						}
 					}
 				}

--- a/cmake/PolyfemDownloadExternal.cmake
+++ b/cmake/PolyfemDownloadExternal.cmake
@@ -35,7 +35,7 @@ endfunction()
 function(polyfem_download_libigl)
     polyfem_download_project(libigl
         GIT_REPOSITORY https://github.com/libigl/libigl.git
-        GIT_TAG        45cfc79fede992ea3923ded9de3c21d1c4faced1
+        GIT_TAG        v2.3.0
     )
 endfunction()
 

--- a/src/viewer/UIMenu.cpp
+++ b/src/viewer/UIMenu.cpp
@@ -92,7 +92,7 @@ void polyfem::UIState::draw_menu()
 		"Viewer", &_viewer_menu_visible,
 		ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove);
 	draw_viewer_menu();
-	draw_labels_window();
+	// draw_labels_window();
 	draw_screenshot();
 	ImGui::End();
 
@@ -504,7 +504,7 @@ void polyfem::UIState::draw_debug()
 				update_slices();
 			}
 		}
-		if (ImGui::InputFloat("Coord", &slice_position, 0.1f, 1.f, 3))
+		if (ImGui::InputFloat("Coord", &slice_position, 0.1f, 1.f, "%.3f"))
 		{
 			if (is_slicing)
 			{

--- a/src/viewer/UIState.cpp
+++ b/src/viewer/UIState.cpp
@@ -608,8 +608,8 @@ namespace polyfem
 		data(layer).show_overlay = 1;
 		data(layer).show_faces = 1;
 		data(layer).show_lines = 1;
-		data(layer).show_vertid = 0;
-		data(layer).show_faceid = 0;
+		data(layer).show_vertex_labels = 0;
+		data(layer).show_face_labels = 0;
 	}
 
 	void UIState::hide_data(const Visualizations &layer)
@@ -620,14 +620,15 @@ namespace polyfem
 				data(layer).show_overlay,
 				data(layer).show_faces,
 				data(layer).show_lines,
-				data(layer).show_vertid,
-				data(layer).show_faceid};
+				data(layer).show_vertex_labels,
+				data(layer).show_face_labels
+            };
 		}
 		data(layer).show_overlay = 0;
 		data(layer).show_faces = 0;
 		data(layer).show_lines = 0;
-		data(layer).show_vertid = 0;
-		data(layer).show_faceid = 0;
+		data(layer).show_vertex_labels = 0;
+		data(layer).show_face_labels = 0;
 	}
 
 	void UIState::show_data(const Visualizations &layer)
@@ -637,8 +638,8 @@ namespace polyfem
 		data(layer).show_overlay = flags[0];
 		data(layer).show_faces = flags[1];
 		data(layer).show_lines = flags[2];
-		data(layer).show_vertid = flags[3];
-		data(layer).show_faceid = flags[4];
+		data(layer).show_vertex_labels = flags[3];
+		data(layer).show_face_labels = flags[4];
 	}
 
 	UIState::UIState()


### PR DESCRIPTION
Updated the libigl version to the latest release (v2.3.0) to fix the build on macOS with CMake 3.19.0.

* Updated `ImGui::InputFloat` and viewer labels
* Could not find an equivalent function to `draw_labels_window()` in the current version of libigl, so I left it commented out