### PR TITLE
Fixed Newton regularization scheme

### DIFF
--- a/src/solver/SparseNewtonDescentSolver.hpp
+++ b/src/solver/SparseNewtonDescentSolver.hpp
@@ -70,7 +70,7 @@ namespace cppoptlib
 
 		// Regularization Coefficients
 		double reg_weight = 0;
-		static constexpr double reg_weight_min = 1e-8;
+		static constexpr double reg_weight_min = 1e-8; // needs to be greater than zero
 		static constexpr double reg_weight_max = 1e8;
 		static constexpr double reg_weight_inc = 10;
 		static constexpr double reg_weight_dec = 2;
@@ -164,12 +164,23 @@ namespace cppoptlib
 				polyfem::logger().trace("linear solve residual {}", residual);
 			}
 
+			// do this check here because we need to repeat the solve without resetting reg_weight
+			if (grad.dot(direction) >= 0)
+			{
+				increase_descent_strategy();
+				polyfem::logger().log(
+					this->descent_strategy == 2 ? spdlog::level::warn : spdlog::level::debug,
+					"[{}] direction is not a descent direction (Δx⋅g={}≥0); reverting to {}",
+					name(), direction.dot(grad), descent_strategy_name());
+				return compute_update_direction(objFunc, x, grad, direction);
+			}
+
 			json info;
 			linear_solver->getInfo(info);
 			internal_solver_info.push_back(info);
 
 			reg_weight /= reg_weight_dec;
-			if (reg_weight < 1e-8)
+			if (reg_weight < reg_weight_min)
 				reg_weight = 0;
 
 			return true;


### PR DESCRIPTION
The regularization was not working in Newton because it would decrease the `reg_weight` and then NLSolver would increase it. This lead to a cycle of `reg_weight=0` then `reg_weight=1e-8` then `reg_weight=0` and repeat.