### PR TITLE
Fix Volume Selection

### DIFF
--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     polyfem_data
     GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-    GIT_TAG 858d3b01a973a4fa48600967a915fad1b8e88465
+    GIT_TAG e01a2b33e3c217b27f2cdcaa2245d78a9a010a95
     GIT_SHALLOW FALSE
     SOURCE_DIR ${POLYFEM_DATA_ROOT}
 )

--- a/input-spec.json
+++ b/input-spec.json
@@ -247,7 +247,7 @@
         "doc": "List of selection (id assignment) operations to apply to the geometry; operations can be box, sphere, etc."
     },
     {
-        "pointer": "/geometry/*/#volume_selection",
+        "pointer": "/geometry/*/volume_selection",
         "type": "file",
         "extensions": [
             ".txt"

--- a/input-spec.json
+++ b/input-spec.json
@@ -223,16 +223,173 @@
     {
         "pointer": "/geometry/*/volume_selection",
         "type": "int",
-        "default": 0,
-        "doc": "Assign specified id to all volume elements of the geometry"
+        "default": -1,
+        "doc": "Assign specified id to all volume elements of the geometry (negative values indicate using the stored values in the MSH (default: 0))."
     },
     {
         "pointer": "/geometry/*/volume_selection",
+        "type": "object",
+        "required": [
+            "id_offset"
+        ],
+        "typename": "id_offset",
+        "doc": "Offsets the volume IDs loaded from the mesh."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/id_offset",
+        "type": "int",
+        "default": 0,
+        "doc": "Offsets the volume IDs loaded from the mesh."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection",
+        "type": "list",
+        "doc": "List of selection (id assignment) operations to apply to the geometry; operations can be box, sphere, etc."
+    },
+    {
+        "pointer": "/geometry/*/#volume_selection",
         "type": "file",
         "extensions": [
             ".txt"
         ],
         "doc": "Load ids from a file; the file is required to have one id per volume element of the geometry"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*",
+        "type": "object",
+        "required": [
+            "id",
+            "box"
+        ],
+        "optional": [
+            "relative"
+        ],
+        "default": null,
+        "typename": "box",
+        "doc": "Assign the id to all volume elements with barycenters inside an axis-aligned box given by the list of its 2 corners, one with min, the other with max coordinates along all axes.  If relative option is set to true, the coordinates of the box corners are specified in bilinear/trilinear coordinates  with respect to the bounding box of the geometry."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*",
+        "type": "object",
+        "required": [
+            "id",
+            "radius",
+            "center"
+        ],
+        "optional": [
+            "relative"
+        ],
+        "default": null,
+        "typename": "sphere",
+        "doc": "Assign the id to all volume elements with barycenters inside a sphere with specified center and radius.  If relative option is set to true, the coordinates of the  center are specified in bilinear/trilinear coordinates with respect to the bounding box of the geometry, and the radius is specified relative to the bounding box diagonal length."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*",
+        "type": "object",
+        "required": [
+            "id",
+            "point",
+            "normal"
+        ],
+        "optional": [
+            "relative",
+            "offset"
+        ],
+        "default": null,
+        "typename": "plane",
+        "doc": "Assign the id to all volume elements with barycenters in a halfspace. The halfspace boundary plane is defined in one of two ways: (1) by a point in the plane and the normal, which points to the halfspace. (2) By a normal and the offset from the coordinate system origin along the line in the direction of the normal passing through the origin. In the former case, the option relative set to true indicates that the point position is specified in bilinear/trilinear coordinates with respect to the bounding box of the geometry."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*",
+        "type": "object",
+        "required": [
+            "id",
+            "axis",
+            "position"
+        ],
+        "optional": [
+            "relative"
+        ],
+        "default": null,
+        "typename": "axis",
+        "doc": "Same as halfspace, but the boundary plane is axis-aligned. The choice of axis is specified either by a string matching the regexp r\"[+-][xyzXYZ]\" or an int matching the regular expression [+-]?[123] where the sign is the side of the plane to select and letter or number indicates the axis to which the plane is perpendicular. The offset is the plane offset from the origin. If the relative option is set to true, the offset is with respect to the center of the bounding box."
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/id",
+        "type": "int"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/radius",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/center",
+        "type": "list",
+        "min": 2,
+        "max": 3
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/center/*",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/axis",
+        "type": "int"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/axis",
+        "type": "string"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/offset",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/position",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/relative",
+        "type": "bool",
+        "default": false
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/point",
+        "type": "list",
+        "min": 2,
+        "max": 3
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/point/*",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/normal",
+        "type": "list",
+        "min": 2,
+        "max": 3
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/normal/*",
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/box",
+        "type": "list",
+        "min": 2,
+        "max": 2
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/box/*",
+        "type": "list",
+        "min": 2,
+        "max": 3,
+        "default": []
+    },
+    {
+        "pointer": "/geometry/*/volume_selection/*/box/*/*",
+        "type": "float",
+        "default": 0
     },
     {
         "pointer": "/geometry/*/point_selection",
@@ -491,6 +648,49 @@
     {
         "pointer": "/space/discr_order",
         "default": 1,
+        "type": "int",
+        "doc": "Lagrange element order for the space for the main unknown, for all elements."
+    },
+    {
+        "pointer": "/space/discr_order",
+        "type": "file",
+        "extensions": [
+            ".txt",
+            ".bin"
+        ],
+        "doc": "Path to file containing Lagrange element order for the space for the main unknown per element."
+    },
+    {
+        "pointer": "/space/discr_order",
+        "type": "list",
+        "doc": "List of Lagrange element order for the space for the main unknown with volume IDs."
+    },
+    {
+        "pointer": "/space/discr_order/*",
+        "type": "object",
+        "required": [
+            "id",
+            "order"
+        ],
+        "doc": "Lagrange element order for the a space tagged with volume ID for the main unknown."
+    },
+    {
+        "pointer": "/space/discr_order/*/id",
+        "type": "int",
+        "doc": "Volume selection ID to apply the discr_order to."
+    },
+    {
+        "pointer": "/space/discr_order/*/id",
+        "type": "list",
+        "doc": "List of volume selection IDs to apply the discr_order to."
+    },
+    {
+        "pointer": "/space/discr_order/*/id/*",
+        "type": "int",
+        "doc": "Volume selection ID to apply the discr_order to."
+    },
+    {
+        "pointer": "/space/discr_order/*/order",
         "type": "int",
         "doc": "Lagrange element order for the space for the main unknown, for all elements."
     },

--- a/src/polyfem/mesh/GeometryReader.cpp
+++ b/src/polyfem/mesh/GeometryReader.cpp
@@ -50,6 +50,7 @@ namespace polyfem::mesh
 				A, b);
 			mesh->apply_affine_transformation(A, b);
 		}
+
 		mesh->bounding_box(bbox[0], bbox[1]);
 
 		// --------------------------------------------------------------------
@@ -146,22 +147,23 @@ namespace polyfem::mesh
 		// --------------------------------------------------------------------
 
 		// If the selection is of the form {"id_offset": ...}
-		if (j_mesh["volume_selection"].is_object()
-			&& j_mesh["volume_selection"].size() == 1
-			&& j_mesh["volume_selection"].contains("id_offset"))
+		const json volume_selection = j_mesh["volume_selection"];
+		if (volume_selection.is_object()
+			&& volume_selection.size() == 1
+			&& volume_selection.contains("id_offset"))
 		{
-			const int id_offset = j_mesh["volume_selection"]["id_offset"].get<int>();
+			const int id_offset = volume_selection["id_offset"].get<int>();
 			const int n_body_ids = mesh->n_elements();
 			std::vector<int> body_ids(n_body_ids);
 			for (int i = 0; i < n_body_ids; ++i)
 				body_ids[i] = mesh->get_body_id(i) + id_offset;
 			mesh->set_body_ids(body_ids);
 		}
-		else
+		else if (!volume_selection.is_number_integer() || volume_selection.get<int>() >= 0)
 		{
 			// Specified volume selection has priority over mesh's stored ids
 			std::vector<std::shared_ptr<Selection>> volume_selections =
-				build_selections(j_mesh["volume_selection"], root_path, bbox);
+				build_selections(volume_selection, root_path, bbox);
 
 			mesh->compute_body_ids([&](const size_t cell_id, const RowVectorNd &p) -> int {
 				for (const auto &selection : volume_selections)

--- a/src/polyfem/mesh/GeometryReader.hpp
+++ b/src/polyfem/mesh/GeometryReader.hpp
@@ -89,14 +89,4 @@ namespace polyfem::mesh
 		MatrixNd &A,
 		VectorNd &b);
 
-	/// @brief Build a vector of selection objects from a JSON selection(s).
-	/// @param j_selections JSON object of selection(s).
-	/// @param root_path    Root path of the JSON file.
-	/// @param bbox         Bounding box of the mesh.
-	/// @return Vector of selection objects.
-	std::vector<std::shared_ptr<utils::Selection>> build_selections(
-		const json &j_selections,
-		const std::string &root_path,
-		const utils::Selection::BBox &bbox);
-
 } // namespace polyfem::mesh

--- a/src/polyfem/mesh/Mesh.hpp
+++ b/src/polyfem/mesh/Mesh.hpp
@@ -440,6 +440,12 @@ namespace polyfem
 				else
 					return 0;
 			}
+			/// @brief Get the volume selection of all elements (cells in 3d, faces in 2d)
+			/// @return Const reference to the vector of body IDs
+			virtual const std::vector<int> &get_body_ids() const
+			{
+				return body_ids_;
+			}
 			/// @brief checks if surface selections are available
 			///
 			/// @return surface selections are available

--- a/src/polyfem/utils/Selection.hpp
+++ b/src/polyfem/utils/Selection.hpp
@@ -20,9 +20,25 @@ namespace polyfem
 
 			virtual int id(const size_t element_id) const { return id_; }
 
+			/// @brief Build a selection objects from a JSON selection.
+			/// @param j_selections JSON object of selection(s).
+			/// @param mesh_bbox    Bounding box of the mesh.
+			/// @param root_path    Root path of the JSON file.
+			/// @return Shared pointer to selection object.
 			static std::shared_ptr<Selection> build(
-				const json &selection,
-				const BBox &mesh_bbox);
+				const json &j_selections,
+				const BBox &mesh_bbox,
+				const std::string &root_path = "");
+
+			/// @brief Build a vector of selection objects from a JSON selection(s).
+			/// @param j_selections JSON object of selection(s).
+			/// @param mesh_bbox    Bounding box of the mesh.
+			/// @param root_path    Root path of the JSON file.
+			/// @return Vector of selection objects.
+			static std::vector<std::shared_ptr<utils::Selection>> build_selections(
+				const json &j_selections,
+				const BBox &mesh_bbox,
+				const std::string &root_path = "");
 
 		protected:
 			Selection() {}


### PR DESCRIPTION
Volume selections were missing a large number of specifications in the JSON spec. 

This adds them and changes the default. The default in the spec is -1 which in the code is used to indicate either a default of 0 or the values loaded from the MSH file.