### PR TITLE
Common JSON root_path and patch

### DIFF
--- a/src/polyfem/utils/JSONUtils.cpp
+++ b/src/polyfem/utils/JSONUtils.cpp
@@ -16,7 +16,7 @@ namespace polyfem
 			if (!args.contains("common"))
 				return;
 
-			std::string common_params_path = resolve_path(args["common"], args["root_path"]);
+			const std::string common_params_path = resolve_path(args["common"], args["root_path"]);
 
 			if (common_params_path.empty())
 				return;
@@ -30,8 +30,18 @@ namespace polyfem
 			file.close();
 
 			// Recursively apply common params
-			common_params["root_path"] = common_params_path;
+			const bool has_root_path = common_params.contains("root_path");
+			if (has_root_path)
+				common_params["root_path"] = resolve_path(common_params["root_path"], common_params_path);
+			else
+				common_params["root_path"] = common_params_path;
 			apply_common_params(common_params);
+
+			// If there is a root path in the common params, it overrides the one in the current params.
+			// This is somewhat backwards as normally current params override common params, but this is
+			// an easy way to make sure that the relative paths in common are correct.
+			if (has_root_path)
+				args["root_path"] = common_params["root_path"];
 
 			json patch;
 			if (args.contains("patch"))

--- a/src/polyfem/utils/JSONUtils.cpp
+++ b/src/polyfem/utils/JSONUtils.cpp
@@ -33,7 +33,16 @@ namespace polyfem
 			common_params["root_path"] = common_params_path;
 			apply_common_params(common_params);
 
+			json patch;
+			if (args.contains("patch"))
+			{
+				patch = args["patch"];
+				args.erase("patch");
+			}
+
 			common_params.merge_patch(args);
+			if (!patch.empty())
+				common_params = common_params.patch(patch);
 			args = common_params;
 		}
 


### PR DESCRIPTION
## Preserve common's `"root_path"`

* If there is a `"root_path"` entry in the common JSON, then preserve it and apply it on top of the child.
* This is necessary if "common" lives in another directory and we do not override all of the file paths

## Explicit JSON Patching

* Adds a field `"patch"` to the input JSON that contains a JSON patch object(s) (https://jsonpatch.com/)
* This is different from the `merge_patch` because it allows us to set a specific entry of an array in the parent
* For example, I can have a common like this:
```json
{
    "geometry": [{
        "mesh": "REPLACE_ME"
    }, {
        "mesh": "square.obj",
        "is_obstacle": true,
        "transformation": {
            "translation": [-1, 0]
        }
    }, {
        "mesh": "square.obj",
        "is_obstacle": true,
        "transformation": {
            "translation": [1, 0]
        }
    }]
}
```
and a patch JSON
```json
{
    "common": "common.json",
    "patch": [{
        "op": "replace",
        "path": "/geometry/0/mesh",
        "value": "beam/isotropic_h=0.1.msh"
    }]
}
```
which will only replace the mesh in the first geometry. This is more compact with fewer copy-paste errors than using only `merge_patch`.