### PR TITLE
Made second_derivative const in forms

### DIFF
--- a/src/polyfem/solver/forms/ALForm.cpp
+++ b/src/polyfem/solver/forms/ALForm.cpp
@@ -69,7 +69,7 @@ namespace polyfem::solver
 		gradv = masked_lumped_mass_ * (x - target_x_);
 	}
 
-	void ALForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void ALForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		hessian = masked_lumped_mass_;
 	}

--- a/src/polyfem/solver/forms/ALForm.hpp
+++ b/src/polyfem/solver/forms/ALForm.hpp
@@ -44,7 +44,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Update time dependent quantities

--- a/src/polyfem/solver/forms/BodyForm.hpp
+++ b/src/polyfem/solver/forms/BodyForm.hpp
@@ -45,7 +45,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override { hessian.resize(x.size(), x.size()); }
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override { hessian.resize(x.size(), x.size()); }
 
 	public:
 		/// @brief Update time dependent quantities

--- a/src/polyfem/solver/forms/ContactForm.cpp
+++ b/src/polyfem/solver/forms/ContactForm.cpp
@@ -96,7 +96,7 @@ namespace polyfem::solver
 		gradv = collision_mesh_.to_full_dof(gradv);
 	}
 
-	void ContactForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void ContactForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		POLYFEM_SCOPED_TIMER("\t\tbarrier hessian");
 		hessian = ipc::compute_barrier_potential_hessian(collision_mesh_, compute_displaced_surface(x), constraint_set_, dhat_, project_to_psd_);

--- a/src/polyfem/solver/forms/ContactForm.hpp
+++ b/src/polyfem/solver/forms/ContactForm.hpp
@@ -50,7 +50,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param x Current solution
 		/// @param hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Update time-dependent fields

--- a/src/polyfem/solver/forms/ElasticForm.cpp
+++ b/src/polyfem/solver/forms/ElasticForm.cpp
@@ -43,7 +43,7 @@ namespace polyfem::solver
 		gradv = grad;
 	}
 
-	void ElasticForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void ElasticForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		POLYFEM_SCOPED_TIMER("\telastic hessian");
 
@@ -56,7 +56,7 @@ namespace polyfem::solver
 		}
 		else
 		{
-			// TODO: somehow remove mat_cache_ so this function can be marked const
+			// NOTE: mat_cache_ is marked as mutable so we can modify it here
 			assembler_.assemble_energy_hessian(
 				formulation_, is_volume_, n_bases_, project_to_psd_, bases_,
 				geom_bases_, ass_vals_cache_, dt_, x, x_prev_, mat_cache_, hessian);

--- a/src/polyfem/solver/forms/ElasticForm.hpp
+++ b/src/polyfem/solver/forms/ElasticForm.hpp
@@ -39,7 +39,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Determine if a step from solution x0 to solution x1 is allowed
@@ -63,8 +63,8 @@ namespace polyfem::solver
 		const std::string formulation_; ///< Elasticity formulation name
 		const bool is_volume_;
 		const double dt_;
-		StiffnessMatrix cached_stiffness_;  ///< Cached stiffness matrix for linear elasticity
-		utils::SpareMatrixCache mat_cache_; ///< Matrix cache
+		StiffnessMatrix cached_stiffness_;          ///< Cached stiffness matrix for linear elasticity
+		mutable utils::SpareMatrixCache mat_cache_; ///< Matrix cache (mutable because it is modified in second_derivative_unweighted)
 
 		/// @brief Compute the stiffness matrix (cached)
 		void compute_cached_stiffness();

--- a/src/polyfem/solver/forms/Form.hpp
+++ b/src/polyfem/solver/forms/Form.hpp
@@ -34,7 +34,7 @@ namespace polyfem::solver
 		/// @note This is not marked const because ElasticForm needs to cache the matrix assembly.
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		inline void second_derivative(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+		inline void second_derivative(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 		{
 			second_derivative_unweighted(x, hessian);
 			hessian *= weight_;
@@ -146,6 +146,6 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		virtual void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) = 0;
+		virtual void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const = 0;
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/FrictionForm.cpp
+++ b/src/polyfem/solver/forms/FrictionForm.cpp
@@ -47,7 +47,7 @@ namespace polyfem::solver
 		gradv = collision_mesh_.to_full_dof(grad_friction);
 	}
 
-	void FrictionForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void FrictionForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		POLYFEM_SCOPED_TIMER("\t\tfriction hessian");
 

--- a/src/polyfem/solver/forms/FrictionForm.hpp
+++ b/src/polyfem/solver/forms/FrictionForm.hpp
@@ -51,7 +51,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Initialize lagged fields

--- a/src/polyfem/solver/forms/InertiaForm.cpp
+++ b/src/polyfem/solver/forms/InertiaForm.cpp
@@ -25,7 +25,7 @@ namespace polyfem::solver
 		gradv = mass_ * (x - time_integrator_.x_tilde());
 	}
 
-	void InertiaForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void InertiaForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		hessian = mass_;
 	}

--- a/src/polyfem/solver/forms/InertiaForm.hpp
+++ b/src/polyfem/solver/forms/InertiaForm.hpp
@@ -31,7 +31,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	private:
 		const StiffnessMatrix &mass_;                                    ///< Mass matrix

--- a/src/polyfem/solver/forms/LaggedRegForm.cpp
+++ b/src/polyfem/solver/forms/LaggedRegForm.cpp
@@ -23,7 +23,7 @@ namespace polyfem::solver
 		gradv = (x - x_lagged_);
 	}
 
-	void LaggedRegForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void LaggedRegForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		hessian.resize(x.size(), x.size());
 		hessian.setIdentity();

--- a/src/polyfem/solver/forms/LaggedRegForm.hpp
+++ b/src/polyfem/solver/forms/LaggedRegForm.hpp
@@ -27,7 +27,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Initialize lagged fields

--- a/src/polyfem/solver/forms/RayleighDampingForm.cpp
+++ b/src/polyfem/solver/forms/RayleighDampingForm.cpp
@@ -53,7 +53,7 @@ namespace polyfem::solver
 		gradv = stiffness() * (lagged_stiffness_matrix_ * v);
 	}
 
-	void RayleighDampingForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian)
+	void RayleighDampingForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		// NOTE: Assumes that v(x) is linear in x, so ∂²v/∂x² = 0
 		hessian = (stiffness() * time_integrator_.dv_dx()) * lagged_stiffness_matrix_;

--- a/src/polyfem/solver/forms/RayleighDampingForm.hpp
+++ b/src/polyfem/solver/forms/RayleighDampingForm.hpp
@@ -39,7 +39,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) override;
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Initialize lagged fields
@@ -62,8 +62,7 @@ namespace polyfem::solver
 		double stiffness() const;
 
 	private:
-		// TODO: Make this const by making ElasticForm::second_derivative const
-		Form &form_to_damp_;                                             ///< Reference to the form we are damping
+		const Form &form_to_damp_;                                       ///< Reference to the form we are damping
 		const time_integrator::ImplicitTimeIntegrator &time_integrator_; ///< Reference to the time integrator
 		const bool use_stiffness_as_ratio_;                              ///< Whether to use the stiffness ratio or the stiffness value
 		const double stiffness_;                                         ///< Damping stiffness coefficient


### PR DESCRIPTION
The only thing preventing us from making the `Form::second_derivative` as const (like the value and first derivative) was that the `ElasticForm::second_derivative_unweighted` modifies the `utils::SpareMatrixCache mat_cache_` field in the class. We can mark this function as `const` if we mark `mat_cache_` as `mutable`. I think this is still clean because `mat_cache_` is only used in this one function and is a private variable (i.e., nothing has changed from the point of view of an external viewer).