### PR TITLE
Many changes I made to the main PolyFEM during the SIGGRAPH deadline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,9 @@ endif()
 # CMake Policies
 ################################################################################
 
-# cmake_policy(VERSION 3.24)
-# cmake_policy(SET CMP0135 NEW) # https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+    cmake_policy(SET CMP0135 NEW) # https://cmake.org/cmake/help/latest/policy/CMP0135.html
+endif()
 
 ################################################################################
 project(PolyFEM DESCRIPTION "A polyvalent C++ FEM library")
@@ -75,6 +76,7 @@ set_property(CACHE POLYFEM_THREADING PROPERTY STRINGS "CPP" "TBB" "NONE")
 option(POLYFEM_WITH_REMESHING "Uses VMTK for remeshing"                     OFF)
 option(POLYFEM_WITH_TESTS     "Build tests"                                 ON)
 option(POLYFEM_WITH_CLIPPER   "Use clipper, necessary for polygonal bases"  ON)
+# option(POLYFEM_WITH_MMG       "Build MMG utils for remeshing"               OFF)
 
 #Solver
 option(POLYSOLVE_WITH_CHOLMOD          "Enable Cholmod library"            ON)
@@ -203,7 +205,7 @@ target_link_libraries(polyfem PUBLIC mshio)
 include(geogram)
 target_link_libraries(polyfem PUBLIC geogram)
 
-#spdlog
+# spdlog
 include(spdlog)
 target_link_libraries(polyfem PUBLIC spdlog::spdlog)
 
@@ -223,18 +225,9 @@ target_link_libraries(polyfem PUBLIC tinyexpr::tinyexpr)
 include(tinyxml)
 target_link_libraries(polyfem PUBLIC tinyxml2)
 
-
-# jse library
+# JSON Specification Engine library
 include(jse)
 target_link_libraries(polyfem PUBLIC jse::jse)
-
-
-if(POLYFEM_WITH_REMESHING)
-    # wmtk library
-    include(wmtk)
-    target_link_libraries(polyfem PUBLIC wmtk::toolkit)
-    target_compile_definitions(polyfem PUBLIC -DPOLYFEM_WITH_REMESHING)
-endif()
 
 # HighFive + HDF5 library
 include(hdf5)
@@ -251,47 +244,32 @@ target_link_libraries(polyfem PUBLIC natsort::natsort)
 include(glob)
 target_link_libraries(polyfem PUBLIC Glob::Glob)
 
-# Extra warnings (include this at the end to have highest priority)
-target_link_libraries(polyfem PRIVATE polyfem::warnings)
-
 ################################################################################
 # Optional libraries
 ################################################################################
 
 # # MMG wrapper
-# if(POLYFEM_WITH_MMG)
-#     include(ExternalProject)
-#     set(MMG_DIR "${POLYFEM_DATA_DIR}/mmg")
-#     ExternalProject_Add(MMG_Project
-#         PREFIX "${MMG_DIR}"
-#         GIT_REPOSITORY https://github.com/MmgTools/mmg.git
-#         GIT_TAG "v5.3.8"
+if(POLYFEM_WITH_MMG)
+    include(mmg)
+    target_link_libraries(polyfem PUBLIC mmg::mmg)
+    target_compile_definitions(polyfem PUBLIC -DPOLYFEM_WITH_MMG)
+endif()
 
-#         UPDATE_COMMAND ""
-#         PATCH_COMMAND ""
-
-#         CMAKE_ARGS
-#             -DCMAKE_PREFIX_PATH=${MMG_DIR}/bin
-#             -DBUILD_SHARED_LIBS=OFF
-#             "-DCMAKE_INSTALL_PREFIX=${MMG_DIR}/"
-
-#         TEST_COMMAND "")
-
-#     set(MMG_PATH "${POLYFEM_DATA_DIR}/mmg/bin/mmg3d_O3")
-#     target_compile_definitions(polyfem PUBLIC -DPOLYFEM_MMG_PATH=\"${MMG_PATH}\")
-#     target_compile_definitions(polyfem PUBLIC -DPOLYFEM_WITH_MMG)
-
-#     # Boost
-#     find_package(Boost 1.61 QUIET REQUIRED COMPONENTS filesystem system)
-#     target_include_directories(polyfem PUBLIC ${Boost_INCLUDE_DIRS})
-#     target_link_libraries(polyfem PUBLIC ${Boost_LIBRARIES})
-# endif()
+if(POLYFEM_WITH_REMESHING)
+    # wmtk library
+    include(wmtk)
+    target_link_libraries(polyfem PUBLIC wmtk::toolkit)
+    target_compile_definitions(polyfem PUBLIC -DPOLYFEM_WITH_REMESHING)
+endif()
 
 if(POLYFEM_WITH_CLIPPER)
     include(clipper)
     target_link_libraries(polyfem PUBLIC clipper::clipper)
     target_compile_definitions(polyfem PUBLIC -DPOLYFEM_WITH_CLIPPER)
 endif()
+
+# Extra warnings (link this here so it has top priority)
+target_link_libraries(polyfem PRIVATE polyfem::warnings)
 
 ################################################################################
 # Polyfem binary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ set_property(CACHE POLYFEM_THREADING PROPERTY STRINGS "CPP" "TBB" "NONE")
 option(POLYFEM_WITH_REMESHING "Uses VMTK for remeshing"                     OFF)
 option(POLYFEM_WITH_TESTS     "Build tests"                                 ON)
 option(POLYFEM_WITH_CLIPPER   "Use clipper, necessary for polygonal bases"  ON)
-# option(POLYFEM_WITH_MMG       "Build MMG utils for remeshing"               OFF)
+option(POLYFEM_WITH_MMG       "Build MMG utils for remeshing"               OFF)
 
 #Solver
 option(POLYSOLVE_WITH_CHOLMOD          "Enable Cholmod library"            ON)

--- a/cmake/recipes/libigl.cmake
+++ b/cmake/recipes/libigl.cmake
@@ -17,29 +17,15 @@ endif()
 
 message(STATUS "Third-party: creating target 'igl::core'")
 
+set(LIBIGL_PREDICATES ON CACHE BOOL "Use exact predicates" FORCE)
+
+include(eigen)
+
 include(FetchContent)
 FetchContent_Declare(
     libigl
     GIT_REPOSITORY https://github.com/libigl/libigl.git
-    GIT_TAG v2.3.0
+    GIT_TAG v2.4.0
     GIT_SHALLOW TRUE
 )
-FetchContent_GetProperties(libigl)
-if(libigl_POPULATED)
-    return()
-endif()
-FetchContent_Populate(libigl)
-
-include(eigen)
-
-set(LIBIGL_WITH_PREDICATES ON CACHE BOOL "Use exact predicates" FORCE)
-
-list(APPEND CMAKE_MODULE_PATH ${libigl_SOURCE_DIR}/cmake)
-include(${libigl_SOURCE_DIR}/cmake/libigl.cmake ${libigl_BINARY_DIR})
-
-# Install rules
-set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME libigl)
-set_target_properties(igl PROPERTIES EXPORT_NAME core)
-install(DIRECTORY ${libigl_SOURCE_DIR}/include/igl DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(TARGETS igl igl_common EXPORT Libigl_Targets)
-install(EXPORT Libigl_Targets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/igl NAMESPACE igl::)
+FetchContent_MakeAvailable(libigl)

--- a/cmake/recipes/mmg.cmake
+++ b/cmake/recipes/mmg.cmake
@@ -1,0 +1,26 @@
+# WMTK
+# License: LGPL
+
+if(TARGET mmg::mmg)
+    return()
+endif()
+
+message(STATUS "Third-party: creating target 'mmg::mmg'")
+
+option(BUILD_TESTING "Enable/Disable continuous integration" OFF)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+include(FetchContent)
+FetchContent_Declare(
+    mmg
+    GIT_REPOSITORY https://github.com/MmgTools/mmg.git
+    GIT_TAG v5.6.0
+    # GIT_TAG 88e2dd6cc773c43141b137fd0972c0eb2f4bbd2a
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(mmg)
+
+add_library(mmg::mmg ALIAS libmmg_a)
+add_library(mmg::mmgs ALIAS libmmgs_a)
+add_library(mmg::mmg2d ALIAS libmmg2d_a)
+add_library(mmg::mmg3d ALIAS libmmg3d_a)

--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -27,7 +27,7 @@ else()
         PREFIX ${FETCHCONTENT_BASE_DIR}/polyfem-test-data
         SOURCE_DIR ${POLYFEM_DATA_DIR}
         GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-        GIT_TAG db18d5bacb4cce42c85cd6f03cd1ddfd2f19e962
+        GIT_TAG 570769122e4adf6caf558123a018136cc02f4bc5
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/cmake/recipes/polysolver.cmake
+++ b/cmake/recipes/polysolver.cmake
@@ -12,7 +12,7 @@ include(FetchContent)
 FetchContent_Declare(
     polysolve
     GIT_REPOSITORY https://github.com/polyfem/polysolve.git
-    GIT_TAG 421ad443b1d1f652f9ac2acf9b2816215f5a7d4f
+    GIT_TAG e53ab52e334ade50520961d2a11431baf52ea08d
     GIT_SHALLOW FALSE
 )
 FetchContent_MakeAvailable(polysolve)

--- a/input-spec.json
+++ b/input-spec.json
@@ -1,5 +1,4 @@
-[
-    {
+[{
         "pointer": "/",
         "type": "object",
         "required": [
@@ -35,7 +34,7 @@
         "pointer": "/root_path",
         "default": "",
         "type": "string",
-        "doc": "Path for all relative paths, set automatically to the folder containing this json."
+        "doc": "Path for all relative paths, set automatically to the folder containing this JSON."
     },
     {
         "pointer": "/tests",
@@ -1384,7 +1383,8 @@
             "dhat",
             "dhat_percentage",
             "epsv",
-            "friction_coefficient"
+            "friction_coefficient",
+            "use_convergent_formulation"
         ],
         "doc": "Contact handling parameters."
     },
@@ -1419,6 +1419,12 @@
         "default": 0,
         "type": "float",
         "doc": "Coefficient of friction (global)"
+    },
+    {
+        "pointer": "/contact/use_convergent_formulation",
+        "default": false,
+        "type": "bool",
+        "doc": "Whether to use the convergent (area weighted) formulation of IPC."
     },
     {
         "pointer": "/solver",
@@ -1872,10 +1878,10 @@
         "optional": [
             "solver",
             "f_delta",
+            "x_delta",
             "grad_norm",
             "first_grad_norm_tol",
             "max_iterations",
-            "use_grad_norm",
             "relative_gradient",
             "line_search"
         ],
@@ -1895,12 +1901,21 @@
         "pointer": "/solver/nonlinear/f_delta",
         "default": 1e-10,
         "type": "float",
+        "min": 0,
         "doc": "Stopping criterion: minimal change of the energy f for the iterations to continue."
+    },
+    {
+        "pointer": "/solver/nonlinear/x_delta",
+        "default": 0,
+        "type": "float",
+        "min": 0,
+        "doc": "Stopping criterion: minimal change of the variables x for the iterations to continue. Computed as the L2 norm of x divide by the time step."
     },
     {
         "pointer": "/solver/nonlinear/grad_norm",
         "default": 1e-08,
         "type": "float",
+        "min": 0,
         "doc": "Stopping criterion: Minimal gradient norm for the iterations to continue."
     },
     {
@@ -1914,12 +1929,6 @@
         "default": 1000,
         "type": "int",
         "doc": "Maximum number of iterations for a nonlinear solve."
-    },
-    {
-        "pointer": "/solver/nonlinear/use_grad_norm",
-        "default": true,
-        "type": "bool",
-        "doc": "If true, enable gradient-norm stopping criterion, absolute (if relative_gradient is false), or relative to the initial gradient magnitude before the first iteration, otherwise."
     },
     {
         "pointer": "/solver/nonlinear/relative_gradient",
@@ -2424,6 +2433,16 @@
         "pointer": "/materials/*/id",
         "type": "int",
         "default": 0,
+        "doc": "Volume selection ID"
+    },
+    {
+        "pointer": "/materials/*/id",
+        "type": "list",
+        "doc": "Volume selection IDs"
+    },
+    {
+        "pointer": "/materials/*/id/*",
+        "type": "int",
         "doc": "Volume selection ID"
     },
     {
@@ -3386,6 +3405,7 @@
             "directory",
             "log",
             "json",
+            "restart_json",
             "paraview",
             "data",
             "advanced",
@@ -3448,7 +3468,13 @@
         "pointer": "/output/json",
         "default": "",
         "type": "string",
-        "doc": "File name for json output statistics on time/error/etc."
+        "doc": "File name for JSON output statistics on time/error/etc."
+    },
+    {
+        "pointer": "/output/restart_json",
+        "default": "",
+        "type": "string",
+        "doc": "File name for JSON output to restart the simulation."
     },
     {
         "pointer": "/output/paraview",
@@ -3524,6 +3550,7 @@
             "body_ids",
             "contact_forces",
             "friction_forces",
+            "prev_sol",
             "velocity",
             "acceleration"
         ],
@@ -3554,6 +3581,12 @@
         "doc": "If true, write out friction forces for surface"
     },
     {
+        "pointer": "/output/paraview/options/prev_sol",
+        "default": false,
+        "type": "bool",
+        "doc": "If true, write out the previous solution"
+    },
+    {
         "pointer": "/output/paraview/options/velocity",
         "default": false,
         "type": "bool",
@@ -3577,6 +3610,7 @@
             "u_path",
             "v_path",
             "a_path",
+            "rest_mesh",
             "mises",
             "nodes",
             "advanced"
@@ -3624,6 +3658,12 @@
         "default": "",
         "type": "string",
         "doc": "Writes the complete acceleration in PolyFEM format, used to restart the sim"
+    },
+    {
+        "pointer": "/output/data/rest_mesh",
+        "default": "",
+        "type": "string",
+        "doc": "Writes the rest mesh in OBJ format, used to restart the sim"
     },
     {
         "pointer": "/output/data/mises",
@@ -3726,7 +3766,7 @@
         "pointer": "/output/advanced/sol_at_node",
         "default": -1,
         "type": "int",
-        "doc": "Write out solution values at a specific node. the values will be written in the output json file"
+        "doc": "Write out solution values at a specific node. the values will be written in the output JSON file"
     },
     {
         "pointer": "/output/advanced/vis_boundary_only",
@@ -3762,7 +3802,7 @@
         "pointer": "/output/advanced/spectrum",
         "default": false,
         "type": "bool",
-        "doc": "exports the spectrum of the matrix in the output json. Works only if POLYSOLVE_WITH_SPECTRA is enabled"
+        "doc": "exports the spectrum of the matrix in the output JSON. Works only if POLYSOLVE_WITH_SPECTRA is enabled"
     },
     {
         "pointer": "/input",
@@ -3780,27 +3820,34 @@
         "optional": [
             "u_path",
             "v_path",
-            "a_path"
+            "a_path",
+            "reorder"
         ],
         "doc": "input to restart time dependent sim"
     },
     {
         "pointer": "/input/data/u_path",
         "default": "",
-        "type": "string",
+        "type": "file",
         "doc": "input solution"
     },
     {
         "pointer": "/input/data/v_path",
         "default": "",
-        "type": "string",
+        "type": "file",
         "doc": "input velocity"
     },
     {
         "pointer": "/input/data/a_path",
         "default": "",
-        "type": "string",
+        "type": "file",
         "doc": "input acceleration"
+    },
+    {
+        "pointer": "/input/data/reorder",
+        "default": true,
+        "type": "bool",
+        "doc": "reorder input data"
     },
     {
         "pointer": "/preset_problem",

--- a/src/polyfem/State.cpp
+++ b/src/polyfem/State.cpp
@@ -33,7 +33,6 @@
 #include <polyfem/quadrature/TriQuadrature.hpp>
 
 #include <polyfem/utils/Logger.hpp>
-#include <polyfem/utils/JSONUtils.hpp>
 #include <polyfem/utils/Timer.hpp>
 
 #include <igl/Timer.h>
@@ -407,67 +406,6 @@ namespace polyfem
 		assert(sol.size() == n_bases * (problem->is_scalar() ? 1 : mesh->dimension()));
 		pressure = tmp.middleRows(tmp.rows() - n_pressure_bases - fluid_offset, n_pressure_bases);
 		assert(pressure.size() == n_pressure_bases);
-	}
-
-	void State::set_materials()
-	{
-		if (!is_param_valid(args, "materials"))
-			return;
-
-		const auto &body_params = args["materials"];
-
-		if (!body_params.is_array())
-		{
-			assembler.add_multimaterial(0, body_params);
-			return;
-		}
-
-		std::map<int, json> materials;
-		for (int i = 0; i < body_params.size(); ++i)
-		{
-			json mat = body_params[i];
-			json id = mat["id"];
-			if (id.is_array())
-			{
-				for (int j = 0; j < id.size(); ++j)
-					materials[id[j]] = mat;
-			}
-			else
-			{
-				const int mid = id;
-				materials[mid] = mat;
-			}
-		}
-
-		std::set<int> missing;
-
-		std::map<int, int> body_element_count;
-		std::vector<int> eid_to_eid_in_body(mesh->n_elements());
-		for (int e = 0; e < mesh->n_elements(); ++e)
-		{
-			const int bid = mesh->get_body_id(e);
-			body_element_count.try_emplace(bid, 0);
-			eid_to_eid_in_body[e] = body_element_count[bid]++;
-		}
-
-		for (int e = 0; e < mesh->n_elements(); ++e)
-		{
-			const int bid = mesh->get_body_id(e);
-			const auto it = materials.find(bid);
-			if (it == materials.end())
-			{
-				missing.insert(bid);
-				continue;
-			}
-
-			const json &tmp = it->second;
-			assembler.add_multimaterial(e, tmp);
-		}
-
-		for (int bid : missing)
-		{
-			logger().warn("Missing material parameters for body {}", bid);
-		}
 	}
 
 	void compute_integral_constraints(
@@ -928,15 +866,23 @@ namespace polyfem
 
 		if (is_contact_enabled())
 		{
-			if (!has_dhat && args["contact"]["dhat"] > stats.min_edge_length)
+			double min_boundary_edge_length = std::numeric_limits<double>::max();
+			for (const auto &edge : collision_mesh.edges().rowwise())
 			{
-				args["contact"]["dhat"] = double(args["contact"]["dhat_percentage"]) * stats.min_edge_length;
+				const VectorNd v0 = collision_mesh.vertices_at_rest().row(edge(0));
+				const VectorNd v1 = collision_mesh.vertices_at_rest().row(edge(1));
+				min_boundary_edge_length = std::min(min_boundary_edge_length, (v1 - v0).norm());
+			}
+
+			if (!has_dhat && args["contact"]["dhat"] > min_boundary_edge_length)
+			{
+				args["contact"]["dhat"] = double(args["contact"]["dhat_percentage"]) * min_boundary_edge_length;
 				logger().info("dhat set to {}", double(args["contact"]["dhat"]));
 			}
 			else
 			{
-				if (args["contact"]["dhat"] > stats.min_edge_length)
-					logger().warn("dhat larger than min edge, {} > {}", double(args["contact"]["dhat"]), stats.min_edge_length);
+				if (args["contact"]["dhat"] > min_boundary_edge_length)
+					logger().warn("dhat larger than min boundary edge, {} > {}", double(args["contact"]["dhat"]), min_boundary_edge_length);
 			}
 		}
 
@@ -1078,19 +1024,20 @@ namespace polyfem
 
 	void State::build_collision_mesh()
 	{
+		Eigen::MatrixXd node_positions;
 		Eigen::MatrixXi boundary_edges, boundary_triangles;
 		std::vector<Eigen::Triplet<double>> displacement_map_entries;
 		io::OutGeometryData::extract_boundary_mesh(*mesh, n_bases, bases, total_local_boundary,
-												   boundary_nodes_pos, boundary_edges, boundary_triangles, displacement_map_entries);
+												   node_positions, boundary_edges, boundary_triangles, displacement_map_entries);
 
 		Eigen::VectorXi codimensional_nodes;
 		if (obstacle.n_vertices() > 0)
 		{
-			// boundary_nodes_pos uses n_bases that already contains the obstacle
+			// n_bases already contains the obstacle vertices
 			const int n_v = n_bases - obstacle.n_vertices();
 
 			if (obstacle.v().size())
-				boundary_nodes_pos.block(n_v, 0, obstacle.v().rows(), obstacle.v().cols()) = obstacle.v();
+				node_positions.block(n_v, 0, obstacle.v().rows(), obstacle.v().cols()) = obstacle.v();
 
 			if (!displacement_map_entries.empty())
 			{
@@ -1117,7 +1064,7 @@ namespace polyfem
 			}
 		}
 
-		std::vector<bool> is_on_surface = ipc::CollisionMesh::construct_is_on_surface(boundary_nodes_pos.rows(), boundary_edges);
+		std::vector<bool> is_on_surface = ipc::CollisionMesh::construct_is_on_surface(node_positions.rows(), boundary_edges);
 		for (int i = 0; i < codimensional_nodes.size(); i++)
 		{
 			is_on_surface[codimensional_nodes[i]] = true;
@@ -1126,12 +1073,12 @@ namespace polyfem
 		Eigen::SparseMatrix<double> displacement_map;
 		if (!displacement_map_entries.empty())
 		{
-			displacement_map.resize(boundary_nodes_pos.rows(), n_bases);
+			displacement_map.resize(node_positions.rows(), n_bases);
 			displacement_map.setFromTriplets(displacement_map_entries.begin(), displacement_map_entries.end());
 		}
 
 		collision_mesh = ipc::CollisionMesh(is_on_surface,
-											boundary_nodes_pos,
+											node_positions,
 											boundary_edges,
 											boundary_triangles,
 											displacement_map);
@@ -1394,7 +1341,7 @@ namespace polyfem
 			// Pre log the output path for easier watching
 			if (args["output"]["advanced"]["save_time_sequence"])
 			{
-				logger().info("Time sequence of simulation will be written to: {}",
+				logger().info("Time sequence of simulation will be written to: \"{}\"",
 							  resolve_output_path(args["output"]["paraview"]["file_name"]));
 			}
 

--- a/src/polyfem/assembler/Assembler.cpp
+++ b/src/polyfem/assembler/Assembler.cpp
@@ -114,7 +114,7 @@ namespace polyfem::assembler
 		// #ifdef POLYFEM_WITH_TBB
 		// 		buffer_size /= tbb::task_scheduler_init::default_num_threads();
 		// #endif
-		logger().debug("buffer_size {}", buffer_size);
+		logger().trace("buffer_size {}", buffer_size);
 		try
 		{
 			stiffness.resize(n_basis * local_assembler_.size(), n_basis * local_assembler_.size());
@@ -188,7 +188,7 @@ namespace polyfem::assembler
 											if (local_storage.cache.entries_size() >= max_triplets_size)
 											{
 												local_storage.cache.prune();
-												logger().debug("cleaning memory. Current storage: {}. mat nnz: {}", local_storage.cache.capacity(), local_storage.cache.non_zeros());
+												logger().trace("cleaning memory. Current storage: {}. mat nnz: {}", local_storage.cache.capacity(), local_storage.cache.non_zeros());
 											}
 										}
 									}
@@ -206,7 +206,7 @@ namespace polyfem::assembler
 			});
 
 			timerg.stop();
-			logger().debug("done separate assembly {}s...", timerg.getElapsedTime());
+			logger().trace("done separate assembly {}s...", timerg.getElapsedTime());
 
 			// Assemble the stiffness matrix by concatenating the tuples in each local storage
 			igl::Timer timer1, timer2, timer3;
@@ -226,7 +226,7 @@ namespace polyfem::assembler
 				s->cache.prune();
 			});
 			timerg.stop();
-			logger().debug("done pruning triplets {}s...", timerg.getElapsedTime());
+			logger().trace("done pruning triplets {}s...", timerg.getElapsedTime());
 
 			// Prepares for parallel concatenation
 			std::vector<int> offsets(storage.size());
@@ -256,7 +256,7 @@ namespace polyfem::assembler
 				stiffness.makeCompressed();
 				timerg.stop();
 
-				logger().debug("Serial assembly time: {}s...", timerg.getElapsedTime());
+				logger().trace("Serial assembly time: {}s...", timerg.getElapsedTime());
 			}
 			else
 			{
@@ -264,8 +264,8 @@ namespace polyfem::assembler
 				triplets.resize(triplet_count);
 				timer1.stop();
 
-				logger().debug("done allocate triplets {}s...", timer1.getElapsedTime());
-				logger().debug("Triplets Count: {}", triplet_count);
+				logger().trace("done allocate triplets {}s...", timer1.getElapsedTime());
+				logger().trace("Triplets Count: {}", triplet_count);
 
 				timer2.start();
 				// Parallel copy into triplets
@@ -291,14 +291,14 @@ namespace polyfem::assembler
 				});
 
 				timer2.stop();
-				logger().debug("done concatenate triplets {}s...", timer2.getElapsedTime());
+				logger().trace("done concatenate triplets {}s...", timer2.getElapsedTime());
 
 				timer3.start();
 				// Sort and assemble
 				stiffness.setFromTriplets(triplets.begin(), triplets.end());
 				timer3.stop();
 
-				logger().debug("done setFromTriplets assembly {}s...", timer3.getElapsedTime());
+				logger().trace("done setFromTriplets assembly {}s...", timer3.getElapsedTime());
 			}
 
 			// exit(0);

--- a/src/polyfem/assembler/AssemblerUtils.hpp
+++ b/src/polyfem/assembler/AssemblerUtils.hpp
@@ -156,6 +156,7 @@ namespace polyfem
 			Eigen::Matrix<AutodiffScalarGrad, Eigen::Dynamic, 1, 0, 3, 1> kernel(const std::string &assembler, const int dim, const AutodiffGradPt &rvect, const AutodiffScalarGrad &r) const;
 
 			// dispaces to all set parameters of the local assemblers
+			void set_materials(const std::vector<int> &body_ids, const json &body_params);
 			void add_multimaterial(const int index, const json &params);
 			void set_size(const std::string &assembler, const int dim);
 			void init_multimodels(const std::vector<std::string> &materials);

--- a/src/polyfem/assembler/ElementAssemblyValues.hpp
+++ b/src/polyfem/assembler/ElementAssemblyValues.hpp
@@ -9,13 +9,13 @@ namespace polyfem
 {
 	namespace assembler
 	{
-		//stores per elment bases evaluation
+		// stores per elment bases evaluation
 		class ElementAssemblyValues
 		{
 		public:
-			//per basis values
+			// per basis values
 			std::vector<AssemblyValues> basis_values;
-			//inverse transpose jacobian of geom mapping
+			// inverse transpose jacobian of geom mapping
 			std::vector<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 3, 3>> jac_it;
 
 			quadrature::Quadrature quadrature;
@@ -24,17 +24,17 @@ namespace polyfem
 			// img of quadrature points through the geom mapping (global pos in the mesh)
 			Eigen::MatrixXd val; // R^{m x dim}
 
-			// det(∑∇φi.Ni) det fo the jacobian of geometric mapping (constant for P1)
+			// det(∑∇φᵢ⋅Nᵢ) det fo the jacobian of geometric mapping (constant for P1)
 			Eigen::VectorXd det; // R^{m x 1}
 
-			//only poly elements have no parameterization
+			// only poly elements have no parameterization
 			bool has_parameterization = true;
 
-			//computes the per element values at the quadrature points
+			// computes the per element values at the quadrature points
 			void compute(const int el_index, const bool is_volume, const basis::ElementBases &basis, const basis::ElementBases &gbasis);
-			//computes the per element values at the local (ref el) points (pts)
+			// computes the per element values at the local (ref el) points (pts)
 			void compute(const int el_index, const bool is_volume, const Eigen::MatrixXd &pts, const basis::ElementBases &basis, const basis::ElementBases &gbasis);
-			//check if the element is flipped
+			// check if the element is flipped
 			bool is_geom_mapping_positive(const bool is_volume, const basis::ElementBases &gbasis) const;
 
 		private:

--- a/src/polyfem/basis/ElementBases.cpp
+++ b/src/polyfem/basis/ElementBases.cpp
@@ -139,7 +139,7 @@ namespace polyfem
 			Eigen::MatrixXd _nodes(bases.size(), dim);
 			for (int i = 0; i < bases.size(); ++i)
 			{
-				// TODO: why 0?
+				assert(bases[i].global().size() == 1);
 				_nodes.row(i) = bases[i].global()[0].node;
 			}
 			return _nodes;

--- a/src/polyfem/basis/ElementBases.cpp
+++ b/src/polyfem/basis/ElementBases.cpp
@@ -130,5 +130,19 @@ namespace polyfem
 				grads[k] = tmp;
 			}
 		}
+
+		Eigen::MatrixXd ElementBases::nodes() const
+		{
+			if (bases.size() == 0)
+				return Eigen::MatrixXd();
+			const int dim = bases[0].global()[0].node.size();
+			Eigen::MatrixXd _nodes(bases.size(), dim);
+			for (int i = 0; i < bases.size(); ++i)
+			{
+				// TODO: why 0?
+				_nodes.row(i) = bases[i].global()[0].node;
+			}
+			return _nodes;
+		}
 	} // namespace basis
 } // namespace polyfem

--- a/src/polyfem/basis/ElementBases.hpp
+++ b/src/polyfem/basis/ElementBases.hpp
@@ -23,6 +23,9 @@ namespace polyfem
 			// one basis function per node in the element
 			std::vector<Basis> bases;
 
+			// Assemble the global nodal positions of the bases.
+			Eigen::MatrixXd nodes() const;
+
 			// quadrature points to evaluate the basis functions inside the element
 			void compute_quadrature(quadrature::Quadrature &quadrature) const { quadrature_builder_(quadrature); }
 			void compute_mass_quadrature(quadrature::Quadrature &quadrature) const { mass_quadrature_builder_(quadrature); }

--- a/src/polyfem/io/MshReader.cpp
+++ b/src/polyfem/io/MshReader.cpp
@@ -56,10 +56,12 @@ namespace polyfem::io
 		const int max_tag = nodes.max_node_tag;
 		int dim = -1;
 
+		assert(els.entity_blocks.size() > 0);
 		for (const auto &e : els.entity_blocks)
 		{
 			dim = std::max(dim, e.entity_dim);
 		}
+		assert(dim == 2 || dim == 3);
 
 		vertices.resize(n_vertices, dim);
 		std::vector<int> tag_to_index = std::vector<int>(max_tag + 1, -1);

--- a/src/polyfem/io/MshWriter.cpp
+++ b/src/polyfem/io/MshWriter.cpp
@@ -6,52 +6,59 @@ namespace polyfem::io
 {
 	void MshWriter::write(
 		const std::string &path,
-		const mesh::Mesh &mesh,
+		const Eigen::MatrixXd &V,
+		const Eigen::MatrixXi &F,
+		const std::vector<int> &body_ids,
+		const bool is_volume,
 		const bool binary)
 	{
+		assert(body_ids.size() == 0 || body_ids.size() == F.rows());
+
 		mshio::MshSpec out;
 
 		auto &format = out.mesh_format;
-		format.version = "4.1";            // Only version "2.2" and "4.1" are supported.
-		format.file_type = binary ? 1 : 0; // 0: ASCII, 1: binary.
+		format.version = "4.1"; // Only version "2.2" and "4.1" are supported.
+		format.file_type = 0;   // 0: ASCII, 1: binary.
+		// NOTE: binary is broken on Greene
+		// format.file_type = binary ? 1 : 0; // 0: ASCII, 1: binary.
 		format.data_size = sizeof(size_t); // Size of data, defined as sizeof(size_t) = 8.
 
 		auto &nodes = out.nodes;
-		nodes.num_entity_blocks = 1;         // Number of node blocks.
-		nodes.num_nodes = mesh.n_vertices(); // Total number of nodes.
+		nodes.num_entity_blocks = 1; // Number of node blocks.
+		nodes.num_nodes = V.rows();  // Total number of nodes.
 		nodes.min_node_tag = 1;
-		nodes.max_node_tag = mesh.n_vertices();
+		nodes.max_node_tag = V.rows();
 		nodes.entity_blocks.resize(1); // A std::vector of node blocks.
 		{
 			auto &block = nodes.entity_blocks[0];
-			block.entity_dim = mesh.dimension();          // The dimension of the entity.
-			block.entity_tag = 1;                         // The entity these nodes belongs to.
-			block.parametric = 0;                         // 0: non-parametric, 1: parametric.
-			block.num_nodes_in_block = mesh.n_vertices(); // The number of nodes in block.
+			block.entity_dim = V.cols();         // The dimension of the entity.
+			block.entity_tag = 1;                // The entity these nodes belongs to.
+			block.parametric = 0;                // 0: non-parametric, 1: parametric.
+			block.num_nodes_in_block = V.rows(); // The number of nodes in block.
 
-			for (int i = 0; i < mesh.n_vertices(); ++i)
+			for (int i = 0; i < V.rows(); ++i)
 			{
 				block.tags.push_back(i + 1); // A std::vector of unique, positive node tags.
-				const auto p = mesh.point(i);
+				const auto p = V.row(i);
 				block.data.push_back(p(0));
 				block.data.push_back(p(1)); // A std::vector of coordinates (x,y,z,<u>,<v>,<w>,...)
-				block.data.push_back(mesh.is_volume() ? p(2) : 0);
+				block.data.push_back(is_volume ? p(2) : 0);
 			}
 		}
 
 		auto &elements = out.elements;
-		elements.num_entity_blocks = mesh.n_elements(); // Number of element blocks.
-		elements.num_elements = mesh.n_elements();      // Total number of elmeents.
+		elements.num_entity_blocks = F.rows(); // Number of element blocks.
+		elements.num_elements = F.rows();      // Total number of elmeents.
 		elements.min_element_tag = 1;
-		elements.max_element_tag = mesh.n_elements();
-		elements.entity_blocks.resize(mesh.n_elements()); // A std::vector of element blocks.
+		elements.max_element_tag = F.rows();
+		elements.entity_blocks.resize(F.rows()); // A std::vector of element blocks.
 
-		for (int i = 0; i < mesh.n_elements(); ++i)
+		for (int i = 0; i < F.rows(); ++i)
 		{
 			auto &block = elements.entity_blocks[i];
-			block.entity_dim = mesh.dimension(); // The dimension of the elements.
-			block.entity_tag = 1;                // The entity these elements belongs to.
-			const int n_local_v = mesh.n_cell_vertices(i);
+			block.entity_dim = V.cols(); // The dimension of the elements.
+			block.entity_tag = 1;        // The entity these elements belongs to.
+			const int n_local_v = F.cols();
 			// only tet and tri for the moment
 			assert(n_local_v == 3 || n_local_v == 4);
 
@@ -59,8 +66,32 @@ namespace polyfem::io
 			block.num_elements_in_block = 1;             // The number of elements in this block.
 			block.data.push_back(i + 1);
 			for (int j = 0; j < n_local_v; ++j)
-				block.data.push_back(mesh.cell_vertex(i, j) + 1); // See more detail below.
+				block.data.push_back(F(i, j) + 1); // See more detail below.
+
+			// block.entity_tag = body_ids.empty() ? 0 : body_ids[i];
 		}
+
+		// Add physical groups based on body ids
+		// std::vector<int> unique_body_ids = body_ids;
+		// if (unique_body_ids.size() == 0)
+		// 	unique_body_ids.push_back(0); // default body id
+		// std::sort(unique_body_ids.begin(), unique_body_ids.end());
+		// unique_body_ids.erase(std::unique(unique_body_ids.begin(), unique_body_ids.end()), unique_body_ids.end());
+		// for (const int body_id : body_ids)
+		// {
+		// 	if (V.cols() == 2)
+		// 	{
+		// 		out.entities.surfaces.emplace_back();
+		// 		out.entities.surfaces.back().tag = body_id;
+		// 		out.entities.surfaces.back().physical_group_tags.push_back(body_id);
+		// 	}
+		// 	else
+		// 	{
+		// 		out.entities.volumes.emplace_back();
+		// 		out.entities.volumes.back().tag = body_id;
+		// 		out.entities.volumes.back().physical_group_tags.push_back(body_id);
+		// 	}
+		// }
 
 		mshio::save_msh(path, out);
 	}

--- a/src/polyfem/io/MshWriter.cpp
+++ b/src/polyfem/io/MshWriter.cpp
@@ -48,7 +48,7 @@ namespace polyfem::io
 		const bool is_volume,
 		const bool binary)
 	{
-		assert(body_ids.size() == 0 || body_ids.size() == cells.rows());
+		assert(body_ids.size() == 0 || body_ids.size() == cells.size());
 
 		mshio::MshSpec out;
 

--- a/src/polyfem/io/MshWriter.hpp
+++ b/src/polyfem/io/MshWriter.hpp
@@ -18,7 +18,10 @@ namespace polyfem::io
 		/// @param[in] binary output binary or not
 		static void write(
 			const std::string &path,
-			const mesh::Mesh &mesh,
+			const Eigen::MatrixXd &V,
+			const Eigen::MatrixXi &F,
+			const std::vector<int> &body_ids,
+			const bool is_volume,
 			const bool binary = false);
 	};
 } // namespace polyfem::io

--- a/src/polyfem/io/MshWriter.hpp
+++ b/src/polyfem/io/MshWriter.hpp
@@ -13,13 +13,32 @@ namespace polyfem::io
 	public:
 		MshWriter() = delete;
 
-		/// @brief saves the mesh, currently only msh supported
+		/// @brief saves the mesh
 		/// @param[in] path output path
 		/// @param[in] binary output binary or not
 		static void write(
 			const std::string &path,
-			const Eigen::MatrixXd &V,
-			const Eigen::MatrixXi &F,
+			const mesh::Mesh &mesh,
+			const bool binary);
+
+		/// @brief saves the mesh
+		/// @param[in] path output path
+		/// @param[in] binary output binary or not
+		static void write(
+			const std::string &path,
+			const Eigen::MatrixXd &points,
+			const Eigen::MatrixXi &cells,
+			const std::vector<int> &body_ids,
+			const bool is_volume,
+			const bool binary = false);
+
+		/// @brief saves the mesh
+		/// @param[in] path output path
+		/// @param[in] binary output binary or not
+		static void write(
+			const std::string &path,
+			const Eigen::MatrixXd &points,
+			const std::vector<std::vector<int>> &cells,
 			const std::vector<int> &body_ids,
 			const bool is_volume,
 			const bool binary = false);

--- a/src/polyfem/io/OutData.cpp
+++ b/src/polyfem/io/OutData.cpp
@@ -18,8 +18,6 @@
 #include <polyfem/solver/forms/FrictionForm.hpp>
 #include <polyfem/solver/NLProblem.hpp>
 
-#include <polyfem/io/VTUWriter.hpp>
-
 #include <polyfem/utils/EdgeSampler.hpp>
 #include <polyfem/utils/Logger.hpp>
 #include <polyfem/utils/par_for.hpp>
@@ -45,23 +43,6 @@
 
 extern "C" size_t getPeakRSS();
 
-// map BroadPhaseMethod values to JSON as strings
-namespace ipc
-{
-	NLOHMANN_JSON_SERIALIZE_ENUM(
-		ipc::BroadPhaseMethod,
-		{{ipc::BroadPhaseMethod::HASH_GRID, "hash_grid"}, // also default
-		 {ipc::BroadPhaseMethod::HASH_GRID, "HG"},
-		 {ipc::BroadPhaseMethod::BRUTE_FORCE, "brute_force"},
-		 {ipc::BroadPhaseMethod::BRUTE_FORCE, "BF"},
-		 {ipc::BroadPhaseMethod::SPATIAL_HASH, "spatial_hash"},
-		 {ipc::BroadPhaseMethod::SPATIAL_HASH, "SH"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "sweep_and_tiniest_queue"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "STQ"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "sweep_and_tiniest_queue_gpu"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "STQ_GPU"}})
-} // namespace ipc
-
 namespace polyfem::io
 {
 
@@ -70,7 +51,7 @@ namespace polyfem::io
 		const int n_bases,
 		const std::vector<basis::ElementBases> &bases,
 		const std::vector<mesh::LocalBoundary> &total_local_boundary,
-		Eigen::MatrixXd &boundary_nodes_pos,
+		Eigen::MatrixXd &node_positions,
 		Eigen::MatrixXi &boundary_edges,
 		Eigen::MatrixXi &boundary_triangles,
 		std::vector<Eigen::Triplet<double>> &displacement_map_entries)
@@ -83,8 +64,8 @@ namespace polyfem::io
 		{
 			const bool is_simplicial = mesh.is_simplicial();
 
-			boundary_nodes_pos.resize(n_bases + (is_simplicial ? 0 : mesh.n_faces()), 3);
-			boundary_nodes_pos.setZero();
+			node_positions.resize(n_bases + (is_simplicial ? 0 : mesh.n_faces()), 3);
+			node_positions.setZero();
 			const Mesh3D &mesh3d = dynamic_cast<const Mesh3D &>(mesh);
 
 			std::vector<std::tuple<int, int, int>> tris;
@@ -118,7 +99,7 @@ namespace polyfem::io
 								continue;
 
 							int gindex = glob.front().index;
-							boundary_nodes_pos.row(gindex) = glob.front().node;
+							node_positions.row(gindex) = glob.front().node;
 							bary += glob.front().node;
 							loc_nodes.push_back(gindex);
 						}
@@ -132,7 +113,7 @@ namespace polyfem::io
 						bary /= 4;
 
 						const int new_node = n_bases + eid;
-						boundary_nodes_pos.row(new_node) = bary;
+						node_positions.row(new_node) = bary;
 						tris.emplace_back(loc_nodes[1], loc_nodes[0], new_node);
 						tris.emplace_back(loc_nodes[2], loc_nodes[1], new_node);
 						tris.emplace_back(loc_nodes[3], loc_nodes[2], new_node);
@@ -186,7 +167,7 @@ namespace polyfem::io
 							continue;
 
 						int gindex = glob.front().index;
-						boundary_nodes_pos.row(gindex) = glob.front().node;
+						node_positions.row(gindex) = glob.front().node;
 						loc_nodes.push_back(gindex);
 					}
 
@@ -257,8 +238,8 @@ namespace polyfem::io
 		}
 		else
 		{
-			boundary_nodes_pos.resize(n_bases, 2);
-			boundary_nodes_pos.setZero();
+			node_positions.resize(n_bases, 2);
+			node_positions.setZero();
 			const Mesh2D &mesh2d = dynamic_cast<const Mesh2D &>(mesh);
 
 			std::vector<std::pair<int, int>> edges;
@@ -284,7 +265,7 @@ namespace polyfem::io
 							continue;
 
 						int gindex = glob.front().index;
-						boundary_nodes_pos.row(gindex) << glob.front().node(0), glob.front().node(1);
+						node_positions.row(gindex) << glob.front().node(0), glob.front().node(1);
 
 						if (prev_node >= 0)
 							edges.emplace_back(prev_node, gindex);
@@ -946,6 +927,7 @@ namespace polyfem::io
 		material_params = args["output"]["paraview"]["options"]["material"];
 		body_ids = args["output"]["paraview"]["options"]["body_ids"];
 		sol_on_grid = args["output"]["advanced"]["sol_on_grid"] > 0;
+		prev_sol = args["output"]["paraview"]["options"]["prev_sol"];
 		velocity = args["output"]["paraview"]["options"]["velocity"];
 		acceleration = args["output"]["paraview"]["options"]["acceleration"];
 
@@ -1102,7 +1084,7 @@ namespace polyfem::io
 		const std::map<int, Eigen::MatrixXd> &polys = state.polys;
 		const std::map<int, std::pair<Eigen::MatrixXd, Eigen::MatrixXi>> &polys_3d = state.polys_3d;
 		const assembler::AssemblerUtils &assembler = state.assembler;
-		const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> &time_integrator = state.solve_data.time_integrator;
+		const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator = state.solve_data.time_integrator;
 		const std::string &formulation = state.formulation();
 		const mesh::Mesh &mesh = *state.mesh;
 		const mesh::Obstacle &obstacle = state.obstacle;
@@ -1203,7 +1185,10 @@ namespace polyfem::io
 		{
 			fun.conservativeResize(fun.rows() + obstacle.n_vertices(), fun.cols());
 			node_fun.conservativeResize(node_fun.rows() + obstacle.n_vertices(), node_fun.cols());
-			obstacle.update_displacement(t, fun);
+			node_fun.bottomRows(obstacle.n_vertices()).setZero();
+			// obstacle.update_displacement(t, fun);
+			// NOTE: Assuming the obstacle displacement is the last part of the solution
+			fun.bottomRows(obstacle.n_vertices()) = utils::unflatten(sol.bottomRows(obstacle.ndof()), fun.cols());
 		}
 
 		if (problem.has_exact_sol())
@@ -1214,79 +1199,42 @@ namespace polyfem::io
 			if (obstacle.n_vertices() > 0)
 			{
 				exact_fun.conservativeResize(exact_fun.rows() + obstacle.n_vertices(), exact_fun.cols());
-				obstacle.update_displacement(t, exact_fun);
+				// obstacle.update_displacement(t, exact_fun);
+				exact_fun.bottomRows(obstacle.n_vertices()) = utils::unflatten(sol.bottomRows(obstacle.ndof()), fun.cols());
 
 				err.conservativeResize(err.rows() + obstacle.n_vertices(), 1);
 				err.bottomRows(obstacle.n_vertices()).setZero();
 			}
 		}
 
-		io::VTUWriter writer;
+		VTUWriter writer;
 
 		if (opts.solve_export_to_file)
-		{
-			writer.add_field("solution", fun);
 			writer.add_field("nodes", node_fun);
-		}
-		else
-			solution_frames.back().solution = fun;
 
 		if (problem.is_time_dependent())
 		{
 			bool is_time_integrator_valid = time_integrator != nullptr;
-			const Eigen::VectorXd zero_tmp = Eigen::VectorXd::Zero(sol.rows());
+
+			if (opts.prev_sol)
+			{
+				const Eigen::VectorXd prev_sol =
+					is_time_integrator_valid ? (time_integrator->x_prev()) : Eigen::VectorXd::Zero(sol.size());
+				save_volume_vector_field(state, points, opts, "prev_sol", prev_sol, writer);
+			}
+
 			if (opts.velocity)
 			{
-				Eigen::VectorXd vel = zero_tmp;
-				if (is_time_integrator_valid)
-				{
-					const auto &tmp_ti = *static_cast<time_integrator::ImplicitTimeIntegrator *>(time_integrator.get());
-					vel = tmp_ti.v_prev();
-				}
-
-				Eigen::MatrixXd interp_vel;
-				Evaluator::interpolate_function(
-					mesh, problem.is_scalar(), bases, state.disc_orders,
-					state.polys, state.polys_3d, ref_element_sampler,
-					points.rows(), vel, interp_vel, opts.use_sampler, opts.boundary_only);
-				if (obstacle.n_vertices() > 0)
-				{
-					interp_vel.conservativeResize(interp_vel.rows() + obstacle.n_vertices(), interp_vel.cols());
-					obstacle.set_zero(interp_vel); // TODO
-				}
-
-				if (opts.solve_export_to_file)
-				{
-					writer.add_field("velocity", interp_vel);
-				}
-				// TODO: else save to solution frames
+				const Eigen::VectorXd velocity =
+					is_time_integrator_valid ? (time_integrator->v_prev()) : Eigen::VectorXd::Zero(sol.size());
+				save_volume_vector_field(state, points, opts, "velocity", velocity, writer);
 			}
 
 			if (opts.acceleration)
 			{
-				Eigen::VectorXd acc = zero_tmp;
-				if (is_time_integrator_valid)
-				{
-					const auto &tmp_ti = *static_cast<time_integrator::ImplicitTimeIntegrator *>(time_integrator.get());
-					acc = tmp_ti.a_prev();
-				}
-
-				Eigen::MatrixXd interp_acc;
-				Evaluator::interpolate_function(
-					mesh, problem.is_scalar(), bases, state.disc_orders,
-					state.polys, state.polys_3d, ref_element_sampler,
-					points.rows(), acc, interp_acc, opts.use_sampler, opts.boundary_only);
-				if (obstacle.n_vertices() > 0)
-				{
-					interp_acc.conservativeResize(interp_acc.rows() + obstacle.n_vertices(), interp_acc.cols());
-					obstacle.set_zero(interp_acc); // TODO
-				}
-
-				if (opts.solve_export_to_file)
-				{
-					writer.add_field("acceleration", interp_acc);
-				}
-				// TODO: else save to solution frames
+				const Eigen::VectorXd acceleration =
+					is_time_integrator_valid ? (time_integrator->a_prev()) : Eigen::VectorXd::Zero(sol.size());
+				save_volume_vector_field(state, points, opts, "acceleration", acceleration, writer);
 			}
 		}
 
@@ -1508,6 +1456,13 @@ namespace polyfem::io
 
 		// interpolate_function(pts_index, rhs, fun, opts.boundary_only);
 		// writer.add_field("rhs", fun);
+
+		// Write the solution last so it is the default for warp-by-vector
+		if (opts.solve_export_to_file)
+			writer.add_field("solution", fun);
+		else
+			solution_frames.back().solution = fun;
+
 		if (opts.solve_export_to_file)
 		{
 			if (obstacle.n_vertices() > 0)
@@ -1560,6 +1515,35 @@ namespace polyfem::io
 		}
 	}
 
+	void OutGeometryData::save_volume_vector_field(
+		const State &state,
+		const Eigen::MatrixXd &points,
+		const ExportOptions &opts,
+		const std::string &name,
+		const Eigen::VectorXd &field,
+		VTUWriter &writer) const
+	{
+		Eigen::MatrixXd inerpolated_field;
+		Evaluator::interpolate_function(
+			*state.mesh, state.problem->is_scalar(), state.bases, state.disc_orders,
+			state.polys, state.polys_3d, ref_element_sampler,
+			points.rows(), field, inerpolated_field, opts.use_sampler, opts.boundary_only);
+
+		if (state.obstacle.n_vertices() > 0)
+		{
+			inerpolated_field.conservativeResize(
+				inerpolated_field.rows() + state.obstacle.n_vertices(), inerpolated_field.cols());
+			inerpolated_field.bottomRows(state.obstacle.n_vertices()) =
+				utils::unflatten(field.tail(state.obstacle.ndof()), inerpolated_field.cols());
+		}
+
+		if (opts.solve_export_to_file)
+		{
+			writer.add_field(name, inerpolated_field);
+		}
+		// TODO: else save to solution frames
+	}
+
 	void OutGeometryData::save_surface(
 		const std::string &export_surface,
 		const State &state,
@@ -1581,7 +1565,6 @@ namespace polyfem::io
 		const std::string &formulation = state.formulation();
 		const mesh::Mesh &mesh = *state.mesh;
 		const ipc::CollisionMesh &collision_mesh = state.collision_mesh;
-		const Eigen::MatrixXd &boundary_nodes_pos = state.boundary_nodes_pos;
 		const double dhat = state.args["contact"]["dhat"];
 		const double friction_coefficient = state.args["contact"]["friction_coefficient"];
 		const double epsv = state.args["contact"]["epsv"];
@@ -1667,16 +1650,16 @@ namespace polyfem::io
 
 		if (is_contact_enabled && (opts.contact_forces || opts.friction_forces) && opts.solve_export_to_file)
 		{
-			io::VTUWriter writer;
+			VTUWriter writer;
 
 			const int problem_dim = mesh.dimension();
 			const Eigen::MatrixXd full_displacements = utils::unflatten(sol, problem_dim);
 			const Eigen::MatrixXd surface_displacements = collision_mesh.map_displacements(full_displacements);
-			writer.add_field("solution", surface_displacements);
 
 			const Eigen::MatrixXd displaced_surface = collision_mesh.displace_vertices(full_displacements);
 
 			ipc::Constraints constraint_set;
+			constraint_set.use_convergent_formulation = state.args["contact"]["use_convergent_formulation"];
 			constraint_set.build(
 				collision_mesh, displaced_surface, dhat,
 				/*dmin=*/0, state.args["solver"]["contact"]["CCD"]["broad_phase"]);
@@ -1729,19 +1712,21 @@ namespace polyfem::io
 			assert(collision_mesh.vertices_at_rest().rows() == surface_displacements.rows());
 			assert(collision_mesh.vertices_at_rest().cols() == surface_displacements.cols());
 
+			// Write the solution last so it is the default for warp-by-vector
+			writer.add_field("solution", surface_displacements);
+
 			writer.write_mesh(
 				export_surface.substr(0, export_surface.length() - 4) + "_contact.vtu",
 				collision_mesh.vertices_at_rest(),
 				problem_dim == 3 ? collision_mesh.faces() : collision_mesh.edges());
 		}
 
-		io::VTUWriter writer;
+		VTUWriter writer;
 
 		if (opts.solve_export_to_file)
 		{
 
 			writer.add_field("normals", boundary_vis_normals);
-			writer.add_field("solution", fun);
 			if (assembler.is_mixed(formulation))
 				writer.add_field("pressure", interp_p);
 			writer.add_field("discr", discr);
@@ -1754,7 +1739,6 @@ namespace polyfem::io
 		}
 		else
 		{
-			solution_frames.back().solution = fun;
 			if (assembler.is_mixed(formulation))
 				solution_frames.back().pressure = interp_p;
 		}
@@ -1795,6 +1779,13 @@ namespace polyfem::io
 
 			writer.add_field("body_ids", ids);
 		}
+
+		// Write the solution last so it is the default for warp-by-vector
+		if (opts.solve_export_to_file)
+			writer.add_field("solution", fun);
+		else
+			solution_frames.back().solution = fun;
+
 		if (opts.solve_export_to_file)
 			writer.write_mesh(export_surface, boundary_vis_vertices, boundary_vis_elements);
 		else
@@ -1930,8 +1921,7 @@ namespace polyfem::io
 			err = (fun - exact_fun).eval().rowwise().norm();
 		}
 
-		io::VTUWriter writer;
-		writer.add_field("solution", fun);
+		VTUWriter writer;
 		if (problem.has_exact_sol())
 		{
 			writer.add_field("exact", exact_fun);
@@ -1948,6 +1938,8 @@ namespace polyfem::io
 				ref_element_sampler, pts_index, sol, scalar_val, /*use_sampler*/ true, false);
 			writer.add_field("scalar_value", scalar_val);
 		}
+		// Write the solution last so it is the default for warp-by-vector
+		writer.add_field("solution", fun);
 
 		writer.write_mesh(name, points, edges);
 	}
@@ -1992,12 +1984,13 @@ namespace polyfem::io
 			cells[i].push_back(i);
 		}
 
-		io::VTUWriter writer;
+		VTUWriter writer;
 
 		if (opts.solve_export_to_file)
 		{
-			writer.add_field("solution", fun);
 			writer.add_field("sidesets", b_sidesets);
+			// Write the solution last so it is the default for warp-by-vector
+			writer.add_field("solution", fun);
 			writer.write_mesh(path, points, cells, false);
 		}
 	}

--- a/src/polyfem/io/OutData.hpp
+++ b/src/polyfem/io/OutData.hpp
@@ -8,6 +8,8 @@
 
 #include <polyfem/mesh/Mesh.hpp>
 
+#include <polyfem/io/VTUWriter.hpp>
+
 #include <polyfem/utils/RefElementSampler.hpp>
 
 #include <Eigen/Dense>
@@ -53,6 +55,7 @@ namespace polyfem::io
 			bool material_params;
 			bool body_ids;
 			bool sol_on_grid;
+			bool prev_sol;
 			bool velocity;
 			bool acceleration;
 
@@ -77,7 +80,7 @@ namespace polyfem::io
 		/// @param[in] n_bases number of bases
 		/// @param[in] bases bases
 		/// @param[in] total_local_boundary mesh boundaries
-		/// @param[out] boundary_nodes_pos nodes positions
+		/// @param[out] node_positions nodes positions
 		/// @param[out] boundary_edges edges
 		/// @param[out] boundary_triangles triangles
 		/// @param[out] displacement_map map of collision mesh vertices to nodes, empty if identity
@@ -86,7 +89,7 @@ namespace polyfem::io
 			const int n_bases,
 			const std::vector<basis::ElementBases> &bases,
 			const std::vector<mesh::LocalBoundary> &total_local_boundary,
-			Eigen::MatrixXd &boundary_nodes_pos,
+			Eigen::MatrixXd &node_positions,
 			Eigen::MatrixXi &boundary_edges,
 			Eigen::MatrixXi &boundary_triangles,
 			std::vector<Eigen::Triplet<double>> &displacement_map_entries);
@@ -303,6 +306,14 @@ namespace polyfem::io
 			std::vector<std::vector<int>> &elements,
 			Eigen::MatrixXi &el_id,
 			Eigen::MatrixXd &discr) const;
+
+		void save_volume_vector_field(
+			const State &state,
+			const Eigen::MatrixXd &points,
+			const ExportOptions &opts,
+			const std::string &name,
+			const Eigen::VectorXd &field,
+			VTUWriter &writer) const;
 	};
 
 	/// @brief stores all runtime data

--- a/src/polyfem/io/VTUWriter.hpp
+++ b/src/polyfem/io/VTUWriter.hpp
@@ -14,67 +14,64 @@ namespace polyfem
 {
 	namespace io
 	{
-		namespace
+		template <typename T>
+		class VTKDataNode
 		{
-			template <typename T>
-			class VTKDataNode
+
+		public:
+			VTKDataNode(bool binary)
+				: binary_(binary)
+			{
+			}
+
+			VTKDataNode(const std::string &name, const double binary, const std::string &numeric_type, const Eigen::MatrixXd &data = Eigen::MatrixXd(), const int n_components = 1)
+				: name_(name), binary_(binary), numeric_type_(numeric_type), data_(binary_ ? data.transpose() : data), n_components_(n_components)
+			{
+			}
+
+			// const inline Eigen::MatrixXd &data() { return data_; }
+
+			void initialize(const std::string &name, const std::string &numeric_type, const Eigen::MatrixXd &data, const int n_components = 1)
+			{
+				name_ = name;
+				numeric_type_ = numeric_type;
+				data_ = binary_ ? data.transpose() : data;
+				n_components_ = n_components;
+			}
+
+			void write(std::ostream &os) const
 			{
 
-			public:
-				VTKDataNode(bool binary)
-					: binary_(binary)
+				if (binary_)
 				{
-				}
+					utils::base64Layer base64(os);
 
-				VTKDataNode(const std::string &name, const double binary, const std::string &numeric_type, const Eigen::MatrixXd &data = Eigen::MatrixXd(), const int n_components = 1)
-					: name_(name), binary_(binary), numeric_type_(numeric_type), data_(binary_ ? data.transpose() : data), n_components_(n_components)
+					os << "<DataArray type=\"" << numeric_type_ << "\" Name=\"" << name_ << "\" NumberOfComponents=\"" << n_components_ << "\" format=\"binary\">\n";
+					const uint64_t size = data_.size() * sizeof(T);
+					base64.write(size);
+
+					base64.write(data_.data(), data_.size());
+					base64.close();
+					os << "\n";
+				}
+				else
 				{
+					os << "<DataArray type=\"" << numeric_type_ << "\" Name=\"" << name_ << "\" NumberOfComponents=\"" << n_components_ << "\" format=\"ascii\">\n";
+					os << data_;
 				}
+				os << "</DataArray>\n";
+			}
 
-				// const inline Eigen::MatrixXd &data() { return data_; }
+			inline bool empty() const { return data_.size() <= 0; }
 
-				void initialize(const std::string &name, const std::string &numeric_type, const Eigen::MatrixXd &data, const int n_components = 1)
-				{
-					name_ = name;
-					numeric_type_ = numeric_type;
-					data_ = binary_ ? data.transpose() : data;
-					n_components_ = n_components;
-				}
-
-				void write(std::ostream &os) const
-				{
-
-					if (binary_)
-					{
-						utils::base64Layer base64(os);
-
-						os << "<DataArray type=\"" << numeric_type_ << "\" Name=\"" << name_ << "\" NumberOfComponents=\"" << n_components_ << "\" format=\"binary\">\n";
-						const uint64_t size = data_.size() * sizeof(T);
-						base64.write(size);
-
-						base64.write(data_.data(), data_.size());
-						base64.close();
-						os << "\n";
-					}
-					else
-					{
-						os << "<DataArray type=\"" << numeric_type_ << "\" Name=\"" << name_ << "\" NumberOfComponents=\"" << n_components_ << "\" format=\"ascii\">\n";
-						os << data_;
-					}
-					os << "</DataArray>\n";
-				}
-
-				inline bool empty() const { return data_.size() <= 0; }
-
-			private:
-				std::string name_;
-				bool binary_;
-				/// Float32/
-				std::string numeric_type_;
-				Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> data_;
-				int n_components_;
-			};
-		} // namespace
+		private:
+			std::string name_;
+			bool binary_;
+			/// Float32/
+			std::string numeric_type_;
+			Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> data_;
+			int n_components_;
+		};
 
 		class VTUWriter
 		{

--- a/src/polyfem/mesh/Mesh.hpp
+++ b/src/polyfem/mesh/Mesh.hpp
@@ -187,25 +187,33 @@ namespace polyfem
 			/// @param[in] c_id *global* cell id (face for 2d meshes)
 			/// @return  number of vertices
 			virtual int n_cell_vertices(const int c_id) const = 0;
-
-			/// @brief id of the face vertex
-			///
-			/// @param[in] f_id *global* face id
-			/// @param[in] lv_id *local* vertex index
-			/// @return int id of the face vertex
-			virtual int face_vertex(const int f_id, const int lv_id) const = 0;
 			/// @brief id of the edge vertex
 			///
 			/// @param[in] e_id *global* edge id
 			/// @param[in] lv_id *local* vertex index
 			/// @return int id of the face vertex
 			virtual int edge_vertex(const int e_id, const int lv_id) const = 0;
+			/// @brief id of the face vertex
+			///
+			/// @param[in] f_id *global* face id
+			/// @param[in] lv_id *local* vertex index
+			/// @return int id of the face vertex
+			virtual int face_vertex(const int f_id, const int lv_id) const = 0;
 			/// @brief id of the vertex of a cell
 			///
 			/// @param[in] f_id *global* cell id
 			/// @param[in] lv_id *local* vertex id
 			/// @return vertex id
 			virtual int cell_vertex(const int f_id, const int lv_id) const = 0;
+			/// @brief id of the vertex of a element
+			///
+			/// @param[in] el_id *global* element id
+			/// @param[in] lv_id *local* vertex id
+			/// @return vertex id
+			int element_vertex(const int el_id, const int lv_id) const
+			{
+				return (is_volume() ? cell_vertex(el_id, lv_id) : face_vertex(el_id, lv_id));
+			}
 
 			/// @brief is vertex boundary
 			///

--- a/src/polyfem/mesh/Obstacle.cpp
+++ b/src/polyfem/mesh/Obstacle.cpp
@@ -84,8 +84,7 @@ namespace polyfem
 			}
 			else if (faces.size())
 			{
-				logger().error("Obstacle supports only segments and triangles!");
-				return;
+				log_and_throw_error("Obstacle supports only segments and triangles!");
 			}
 
 			v_.conservativeResize(v_.rows() + vertices.rows(), dim_);

--- a/src/polyfem/mesh/Obstacle.hpp
+++ b/src/polyfem/mesh/Obstacle.hpp
@@ -34,6 +34,8 @@ namespace polyfem
 			void append_plane(const VectorNd &point, const VectorNd &normal);
 
 			inline int n_vertices() const { return v_.rows(); }
+			inline int n_edges() const { return e_.rows(); }
+			inline int n_faces() const { return f_.rows(); }
 			inline int dim() const { return dim_; }
 			inline int ndof() const { return n_vertices() * dim(); }
 			inline const Eigen::MatrixXd &v() const { return v_; }

--- a/src/polyfem/mesh/mesh3D/CMesh3D.cpp
+++ b/src/polyfem/mesh/mesh3D/CMesh3D.cpp
@@ -123,7 +123,7 @@ namespace polyfem
 				p.vs.resize(nw);
 				for (int j = 0; j < nw; j++)
 				{
-					fscanf(f, "%d", &(p.vs[j]));
+					fscanf(f, "%u", &(p.vs[j]));
 				}
 			}
 			mesh_.elements.resize(nh);
@@ -138,7 +138,7 @@ namespace polyfem
 
 				for (int j = 0; j < nf; j++)
 				{
-					fscanf(f, "%d", &(h.fs[j]));
+					fscanf(f, "%u", &(h.fs[j]));
 				}
 
 				for (auto fid : h.fs)

--- a/src/polyfem/quadrature/Quadrature.hpp
+++ b/src/polyfem/quadrature/Quadrature.hpp
@@ -9,5 +9,11 @@ namespace polyfem::quadrature
 	public:
 		Eigen::MatrixXd points;
 		Eigen::VectorXd weights;
+
+		int size() const
+		{
+			assert(points.rows() == weights.size());
+			return points.rows();
+		}
 	};
 } // namespace polyfem::quadrature

--- a/src/polyfem/solver/ALSolver.hpp
+++ b/src/polyfem/solver/ALSolver.hpp
@@ -14,9 +14,11 @@ namespace polyfem::solver
 {
 	class ALSolver
 	{
+		using NLSolver = cppoptlib::NonlinearSolver<NLProblem>;
+
 	public:
 		ALSolver(
-			std::shared_ptr<cppoptlib::NonlinearSolver<NLProblem>> nl_solver,
+			std::shared_ptr<NLSolver> nl_solver,
 			std::shared_ptr<ALForm> al_form,
 			const double initial_al_weight,
 			const double scaling,
@@ -30,7 +32,7 @@ namespace polyfem::solver
 	protected:
 		void set_al_weight(NLProblem &nl_problem, const Eigen::VectorXd &x, const double weight, const std::vector<double> &initial_weight);
 
-		std::shared_ptr<cppoptlib::NonlinearSolver<NLProblem>> nl_solver;
+		std::shared_ptr<NLSolver> nl_solver;
 		std::shared_ptr<ALForm> al_form;
 		const double initial_al_weight;
 		const double scaling;
@@ -39,5 +41,4 @@ namespace polyfem::solver
 		// TODO: replace this with a member function
 		std::function<void(const Eigen::VectorXd &)> update_barrier_stiffness;
 	};
-
 } // namespace polyfem::solver

--- a/src/polyfem/solver/CMakeLists.txt
+++ b/src/polyfem/solver/CMakeLists.txt
@@ -13,6 +13,8 @@ set(SOURCES
 	NonlinearSolver.tpp
 	OperatorSplittingSolver.hpp
 	OperatorSplittingSolver.cpp
+	SolveData.cpp
+	SolveData.hpp
 	SparseNewtonDescentSolver.hpp
 	SparseNewtonDescentSolver.tpp
 	TransientNavierStokesSolver.cpp

--- a/src/polyfem/solver/FullNLProblem.cpp
+++ b/src/polyfem/solver/FullNLProblem.cpp
@@ -2,7 +2,7 @@
 
 namespace polyfem::solver
 {
-	FullNLProblem::FullNLProblem(std::vector<std::shared_ptr<Form>> &forms)
+	FullNLProblem::FullNLProblem(const std::vector<std::shared_ptr<Form>> &forms)
 		: forms_(forms)
 	{
 	}

--- a/src/polyfem/solver/FullNLProblem.hpp
+++ b/src/polyfem/solver/FullNLProblem.hpp
@@ -16,7 +16,7 @@ namespace polyfem::solver
 		using typename cppoptlib::Problem<double>::TVector;
 		typedef StiffnessMatrix THessian;
 
-		FullNLProblem(std::vector<std::shared_ptr<Form>> &forms);
+		FullNLProblem(const std::vector<std::shared_ptr<Form>> &forms);
 		virtual void init(const TVector &x0);
 
 		virtual double value(const TVector &x) override;

--- a/src/polyfem/solver/LBFGSSolver.hpp
+++ b/src/polyfem/solver/LBFGSSolver.hpp
@@ -23,7 +23,7 @@ namespace cppoptlib
 		using typename Superclass::Scalar;
 		using typename Superclass::TVector;
 
-		LBFGSSolver(const json &solver_params, const double dt = 1.0);
+		LBFGSSolver(const json &solver_params, const double dt);
 
 		std::string name() const override { return "L-BFGS"; }
 

--- a/src/polyfem/solver/LBFGSSolver.hpp
+++ b/src/polyfem/solver/LBFGSSolver.hpp
@@ -23,7 +23,7 @@ namespace cppoptlib
 		using typename Superclass::Scalar;
 		using typename Superclass::TVector;
 
-		LBFGSSolver(const json &solver_params);
+		LBFGSSolver(const json &solver_params, const double dt = 1.0);
 
 		std::string name() const override { return "L-BFGS"; }
 

--- a/src/polyfem/solver/LBFGSSolver.tpp
+++ b/src/polyfem/solver/LBFGSSolver.tpp
@@ -7,8 +7,8 @@
 namespace cppoptlib
 {
 	template <typename ProblemType>
-	LBFGSSolver<ProblemType>::LBFGSSolver(const json &solver_params)
-		: Superclass(solver_params)
+	LBFGSSolver<ProblemType>::LBFGSSolver(const json &solver_params, const double dt)
+		: Superclass(solver_params, dt)
 	{
 	}
 

--- a/src/polyfem/solver/NLProblem.hpp
+++ b/src/polyfem/solver/NLProblem.hpp
@@ -13,13 +13,20 @@ namespace polyfem::solver
 		using typename FullNLProblem::THessian;
 		using typename FullNLProblem::TVector;
 
+	protected:
+		NLProblem(
+			const int full_size,
+			const std::vector<int> &boundary_nodes,
+			const std::vector<std::shared_ptr<Form>> &forms);
+
+	public:
 		NLProblem(const int full_size,
-				  const std::string &formulation,
 				  const std::vector<int> &boundary_nodes,
 				  const std::vector<mesh::LocalBoundary> &local_boundary,
 				  const int n_boundary_samples,
 				  const assembler::RhsAssembler &rhs_assembler,
-				  const double t, std::vector<std::shared_ptr<Form>> &forms);
+				  const double t,
+				  const std::vector<std::shared_ptr<Form>> &forms);
 
 		double value(const TVector &x) override;
 		void gradient(const TVector &x, TVector &gradv) override;
@@ -52,13 +59,10 @@ namespace polyfem::solver
 
 		void set_apply_DBC(const TVector &x, const bool val);
 
-	private:
-		const std::vector<int> &boundary_nodes_;
-		const std::vector<mesh::LocalBoundary> &local_boundary_;
+	protected:
+		virtual Eigen::MatrixXd boundary_values() const;
 
-		const int n_boundary_samples_;
-		const assembler::RhsAssembler &rhs_assembler_;
-		double t_;
+		const std::vector<int> &boundary_nodes_;
 
 		const int full_size_;    ///< Size of the full problem
 		const int reduced_size_; ///< Size of the reduced problem
@@ -73,6 +77,12 @@ namespace polyfem::solver
 		{
 			return current_size_ == CurrentSize::FULL_SIZE ? full_size() : reduced_size();
 		}
+
+	private:
+		const assembler::RhsAssembler *rhs_assembler_;
+		const std::vector<mesh::LocalBoundary> *local_boundary_;
+		const int n_boundary_samples_;
+		double t_;
 
 		template <class FullMat, class ReducedMat>
 		static void full_to_reduced_aux(const std::vector<int> &boundary_nodes, const int full_size, const int reduced_size, const FullMat &full, ReducedMat &reduced);

--- a/src/polyfem/solver/NonlinearSolver.hpp
+++ b/src/polyfem/solver/NonlinearSolver.hpp
@@ -25,9 +25,10 @@ namespace cppoptlib
 	public:
 		using Superclass = ISolver<ProblemType, /*Ord=*/-1>;
 		using typename Superclass::Scalar;
+		using typename Superclass::TCriteria;
 		using typename Superclass::TVector;
 
-		NonlinearSolver(const polyfem::json &solver_params);
+		NonlinearSolver(const polyfem::json &solver_params, const double dt = 1.0);
 
 		virtual std::string name() const = 0;
 
@@ -41,15 +42,25 @@ namespace cppoptlib
 
 		ErrorCode error_code() const { return m_error_code; }
 
+		const typename Superclass::TCriteria &getStopCriteria() { return this->m_stop; }
+		// setStopCriteria already in ISolver
+
+		bool converged() const
+		{
+			return this->m_status == Status::XDeltaTolerance
+				   || this->m_status == Status::FDeltaTolerance
+				   || this->m_status == Status::GradNormTolerance;
+		}
+
 	protected:
 		// ====================================================================
 		//                        Solver parameters
 		// ====================================================================
 
-		bool use_gradient_norm;
 		bool normalize_gradient;
 		double use_grad_norm_tol;
 		double first_grad_norm_tol;
+		double dt;
 
 		// ====================================================================
 		//                           Solver state

--- a/src/polyfem/solver/NonlinearSolver.hpp
+++ b/src/polyfem/solver/NonlinearSolver.hpp
@@ -28,7 +28,10 @@ namespace cppoptlib
 		using typename Superclass::TCriteria;
 		using typename Superclass::TVector;
 
-		NonlinearSolver(const polyfem::json &solver_params, const double dt = 1.0);
+		/// @brief Construct a new Nonlinear Solver object
+		/// @param solver_params JSON of solver parameters (see input spec.)
+		/// @param dt time step size (use 1 if not time-dependent)
+		NonlinearSolver(const polyfem::json &solver_params, const double dt);
 
 		virtual std::string name() const = 0;
 

--- a/src/polyfem/solver/NonlinearSolver.tpp
+++ b/src/polyfem/solver/NonlinearSolver.tpp
@@ -224,9 +224,8 @@ namespace cppoptlib
 		// Log results
 		// -----------
 
-		// NOTE: the `this->m_stop.iterations > 1` here allows us to use this code as a linear solver without throwing an error
-		// if (this->m_status == Status::IterationLimit && this->m_stop.iterations > 1)
-		// 	log_and_throw_error("[{}] Reached iteration limit (limit={})", name(), this->m_stop.iterations);
+		if (this->m_status == Status::IterationLimit)
+			log_and_throw_error("[{}] Reached iteration limit (limit={})", name(), this->m_stop.iterations);
 		if (this->m_current.iterations == 0)
 			log_and_throw_error("[{}] Unable to take a step", name());
 		if (this->m_status == Status::UserDefined)

--- a/src/polyfem/solver/SolveData.cpp
+++ b/src/polyfem/solver/SolveData.cpp
@@ -1,0 +1,273 @@
+#include "SolveData.hpp"
+
+#include <polyfem/solver/NLProblem.hpp>
+#include <polyfem/solver/forms/Form.hpp>
+#include <polyfem/solver/forms/ALForm.hpp>
+#include <polyfem/solver/forms/BodyForm.hpp>
+#include <polyfem/solver/forms/ContactForm.hpp>
+#include <polyfem/solver/forms/ElasticForm.hpp>
+#include <polyfem/solver/forms/FrictionForm.hpp>
+#include <polyfem/solver/forms/InertiaForm.hpp>
+#include <polyfem/solver/forms/LaggedRegForm.hpp>
+#include <polyfem/solver/forms/RayleighDampingForm.hpp>
+#include <polyfem/time_integrator/ImplicitTimeIntegrator.hpp>
+#include <polyfem/utils/Logger.hpp>
+
+namespace polyfem::solver
+{
+	using namespace polyfem::time_integrator;
+
+	std::vector<std::shared_ptr<Form>> SolveData::init_forms(
+		// General
+		const int dim,
+		const double t,
+
+		// Elastic form
+		const int n_bases,
+		const std::vector<basis::ElementBases> &bases,
+		const std::vector<basis::ElementBases> &geom_bases,
+		const assembler::AssemblerUtils &assembler,
+		const assembler::AssemblyValsCache &ass_vals_cache,
+		const std::string &formulation,
+
+		// Body form
+		const int n_pressure_bases,
+		const std::vector<int> &boundary_nodes,
+		const std::vector<mesh::LocalBoundary> &local_boundary,
+		const std::vector<mesh::LocalBoundary> &local_neumann_boundary,
+		const int n_boundary_samples,
+		const Eigen::MatrixXd &rhs,
+		const Eigen::MatrixXd &sol,
+
+		// Inertia form
+		const bool ignore_inertia,
+		const StiffnessMatrix &mass,
+
+		// Lagged regularization form
+		const double lagged_regularization_weight,
+		const int lagged_regularization_iterations,
+
+		// Augemented lagrangian form
+		// const std::vector<int> &boundary_nodes,
+		// const std::vector<mesh::LocalBoundary> &local_boundary,
+		// const std::vector<mesh::LocalBoundary> &local_neumann_boundary,
+		// const int n_boundary_samples,
+		// const StiffnessMatrix &mass,
+		const polyfem::mesh::Obstacle &obstacle,
+
+		// Contact form
+		const bool contact_enabled,
+		const ipc::CollisionMesh &collision_mesh,
+		const double dhat,
+		const double avg_mass,
+		const bool use_convergent_contact_formulation,
+		const json &barrier_stiffness,
+		const ipc::BroadPhaseMethod broad_phase,
+		const double ccd_tolerance,
+		const long ccd_max_iterations,
+
+		// Friction form
+		const double friction_coefficient,
+		const double epsv,
+		const int friction_iterations,
+
+		// Rayleigh damping form
+		const json &rayleigh_damping)
+	{
+		const bool is_time_dependent = time_integrator != nullptr;
+		assert(!is_time_dependent || time_integrator != nullptr);
+		const double dt = is_time_dependent ? time_integrator->dt() : 0.0;
+		const int ndof = n_bases * dim;
+		// if (is_formulation_mixed) // mixed not supported
+		// 	ndof_ += n_pressure_bases; // pressure is a scalar
+		const bool is_volume = dim == 3;
+
+		std::vector<std::shared_ptr<Form>> forms;
+
+		elastic_form = std::make_shared<ElasticForm>(
+			n_bases, bases, geom_bases, assembler, ass_vals_cache, formulation,
+			dt, is_volume);
+		forms.push_back(elastic_form);
+
+		if (rhs_assembler != nullptr)
+		{
+			body_form = std::make_shared<BodyForm>(
+				ndof, n_pressure_bases, boundary_nodes, local_boundary,
+				local_neumann_boundary, n_boundary_samples, rhs, *rhs_assembler,
+				assembler.density(), /*apply_DBC=*/true, /*is_formulation_mixed=*/false,
+				is_time_dependent);
+			body_form->update_quantities(t, sol);
+			forms.push_back(body_form);
+		}
+
+		inertia_form = nullptr;
+		damping_form = nullptr;
+		if (is_time_dependent)
+		{
+			if (!ignore_inertia)
+			{
+				assert(time_integrator != nullptr);
+				inertia_form = std::make_shared<InertiaForm>(mass, *time_integrator);
+				forms.push_back(inertia_form);
+			}
+
+			if (assembler.has_damping())
+			{
+				damping_form = std::make_shared<ElasticForm>(
+					n_bases, bases, geom_bases, assembler, ass_vals_cache,
+					"Damping", dt, is_volume);
+				forms.push_back(damping_form);
+			}
+		}
+		else
+		{
+			if (lagged_regularization_weight > 0)
+			{
+				forms.push_back(std::make_shared<LaggedRegForm>(lagged_regularization_iterations));
+				forms.back()->set_weight(lagged_regularization_weight);
+			}
+		}
+
+		if (rhs_assembler != nullptr)
+		{
+			al_form = std::make_shared<ALForm>(
+				ndof, boundary_nodes, local_boundary, local_neumann_boundary,
+				n_boundary_samples, mass, *rhs_assembler, obstacle, is_time_dependent, t);
+			forms.push_back(al_form);
+		}
+
+		contact_form = nullptr;
+		friction_form = nullptr;
+		if (contact_enabled)
+		{
+			const bool use_adaptive_barrier_stiffness = !barrier_stiffness.is_number();
+			if (use_adaptive_barrier_stiffness)
+				log_and_throw_error("Adaptive barrier stiffness is disabled for this project!");
+			if (!use_convergent_contact_formulation)
+				log_and_throw_error("Non-convergent contact is disabled for this project!");
+
+			contact_form = std::make_shared<ContactForm>(
+				collision_mesh, dhat, avg_mass, use_convergent_contact_formulation,
+				use_adaptive_barrier_stiffness, is_time_dependent, broad_phase, ccd_tolerance,
+				ccd_max_iterations);
+
+			if (use_adaptive_barrier_stiffness)
+			{
+				contact_form->set_weight(1);
+				// logger().debug("Using adaptive barrier stiffness");
+			}
+			else
+			{
+				assert(barrier_stiffness.is_number());
+				assert(barrier_stiffness.get<double>() > 0);
+				contact_form->set_weight(barrier_stiffness);
+				// logger().debug("Using fixed barrier stiffness of {}", contact_form->barrier_stiffness());
+			}
+
+			forms.push_back(contact_form);
+
+			// ----------------------------------------------------------------
+
+			if (friction_coefficient != 0)
+			{
+				friction_form = std::make_shared<FrictionForm>(
+					collision_mesh, epsv, friction_coefficient, dhat, broad_phase,
+					is_time_dependent ? dt : 1.0, *contact_form, friction_iterations);
+				forms.push_back(friction_form);
+			}
+		}
+
+		std::vector<json> rayleigh_damping_jsons;
+		if (rayleigh_damping.is_array())
+			rayleigh_damping_jsons = rayleigh_damping.get<std::vector<json>>();
+		else
+			rayleigh_damping_jsons.push_back(rayleigh_damping);
+		if (is_time_dependent)
+		{
+			// Map from form name to form so RayleighDampingForm::create can get the correct form to damp
+			const std::unordered_map<std::string, std::shared_ptr<Form>> possible_forms_to_damp = {
+				{"elasticity", elastic_form},
+				{"contact", contact_form},
+			};
+
+			for (const json &params : rayleigh_damping_jsons)
+			{
+				forms.push_back(RayleighDampingForm::create(
+					params, possible_forms_to_damp,
+					*time_integrator));
+			}
+		}
+		else if (rayleigh_damping_jsons.size() > 0)
+		{
+			log_and_throw_error("Rayleigh damping is only supported for time-dependent problems");
+		}
+
+		update_dt();
+
+		return forms;
+	}
+
+	void SolveData::update_barrier_stiffness(const Eigen::VectorXd &x)
+	{
+		// TODO: missing use_adaptive_barrier_stiffness_ if (use_adaptive_barrier_stiffness_ && is_time_dependent_)
+		// if (inertia_form == nullptr)
+		// 	return;
+
+		// if (contact_form)
+		// 	contact_form->update_barrier_stiffness(x, *nl_problem, friction_form);
+
+		if (contact_form == nullptr)
+			return;
+
+		if (!contact_form->use_adaptive_barrier_stiffness())
+			return;
+
+		Eigen::VectorXd grad_energy(x.size(), 1);
+		grad_energy.setZero();
+
+		elastic_form->first_derivative(x, grad_energy);
+
+		if (inertia_form)
+		{
+			Eigen::VectorXd grad_inertia(x.size());
+			inertia_form->first_derivative(x, grad_inertia);
+			grad_energy += grad_inertia;
+		}
+
+		Eigen::VectorXd body_energy(x.size());
+		body_form->first_derivative(x, body_energy);
+		grad_energy += body_energy;
+
+		contact_form->update_barrier_stiffness(x, grad_energy);
+	}
+
+	void SolveData::update_dt()
+	{
+		if (time_integrator) // if is time dependent
+		{
+			assert(elastic_form != nullptr);
+			elastic_form->set_weight(time_integrator->acceleration_scaling());
+			if (body_form)
+				body_form->set_weight(time_integrator->acceleration_scaling());
+			if (damping_form)
+				damping_form->set_weight(time_integrator->acceleration_scaling());
+
+			// TODO: Determine if friction should be scaled by h²
+			// if (friction_form)
+			// 	friction_form->set_weight(time_integrator->acceleration_scaling());
+		}
+	}
+
+	std::unordered_map<std::string, std::shared_ptr<solver::Form>> SolveData::named_forms() const
+	{
+		return {
+			{"contact", contact_form},
+			{"body", body_form},
+			{"augmented_lagrangian", al_form},
+			{"damping", damping_form},
+			{"friction", friction_form},
+			{"inertia", inertia_form},
+			{"elastic", elastic_form},
+		};
+	}
+} // namespace polyfem::solver

--- a/src/polyfem/solver/SolveData.cpp
+++ b/src/polyfem/solver/SolveData.cpp
@@ -141,10 +141,6 @@ namespace polyfem::solver
 		if (contact_enabled)
 		{
 			const bool use_adaptive_barrier_stiffness = !barrier_stiffness.is_number();
-			if (use_adaptive_barrier_stiffness)
-				log_and_throw_error("Adaptive barrier stiffness is disabled for this project!");
-			if (!use_convergent_contact_formulation)
-				log_and_throw_error("Non-convergent contact is disabled for this project!");
 
 			contact_form = std::make_shared<ContactForm>(
 				collision_mesh, dhat, avg_mass, use_convergent_contact_formulation,

--- a/src/polyfem/solver/SolveData.hpp
+++ b/src/polyfem/solver/SolveData.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <polyfem/assembler/AssemblyValsCache.hpp>
+#include <polyfem/assembler/RhsAssembler.hpp>
+#include <polyfem/assembler/AssemblerUtils.hpp>
+#include <polyfem/basis/ElementBases.hpp>
+#include <polyfem/mesh/Obstacle.hpp>
+#include <polyfem/mesh/LocalBoundary.hpp>
+#include <polyfem/utils/JSONUtils.hpp>
+
+#include <ipc/collision_mesh.hpp>
+#include <ipc/broad_phase/broad_phase.hpp>
+
+#include <Eigen/Core>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace polyfem::time_integrator
+{
+	class ImplicitTimeIntegrator;
+} // namespace polyfem::time_integrator
+
+namespace polyfem::solver
+{
+	class NLProblem;
+	class Form;
+	class ContactForm;
+	class FrictionForm;
+	class BodyForm;
+	class ALForm;
+	class InertiaForm;
+	class ElasticForm;
+
+	/// class to store time stepping data
+	class SolveData
+	{
+	public:
+		/// @brief Initialize the forms and return a vector of pointers to them.
+		/// @note Requires rhs_assembler (and time_integrator) to be initialized.
+		std::vector<std::shared_ptr<Form>> init_forms(
+			// General
+			const int dim,
+			const double t,
+
+			// Elastic form
+			const int n_bases,
+			const std::vector<basis::ElementBases> &bases,
+			const std::vector<basis::ElementBases> &geom_bases,
+			const assembler::AssemblerUtils &assembler,
+			const assembler::AssemblyValsCache &ass_vals_cache,
+			const std::string &formulation,
+
+			// Body form
+			const int n_pressure_bases,
+			const std::vector<int> &boundary_nodes,
+			const std::vector<mesh::LocalBoundary> &local_boundary,
+			const std::vector<mesh::LocalBoundary> &local_neumann_boundary,
+			const int n_boundary_samples,
+			const Eigen::MatrixXd &rhs,
+			const Eigen::MatrixXd &sol,
+
+			// Inertia form
+			const bool ignore_inertia,
+			const StiffnessMatrix &mass,
+
+			// Lagged regularization form
+			const double lagged_regularization_weight,
+			const int lagged_regularization_iterations,
+
+			// Augemented lagrangian form
+			// const std::vector<int> &boundary_nodes,
+			// const std::vector<mesh::LocalBoundary> &local_boundary,
+			// const std::vector<mesh::LocalBoundary> &local_neumann_boundary,
+			// const int n_boundary_samples,
+			// const StiffnessMatrix &mass,
+			const polyfem::mesh::Obstacle &obstacle,
+
+			// Contact form
+			const bool contact_enabled,
+			const ipc::CollisionMesh &collision_mesh,
+			const double dhat,
+			const double avg_mass,
+			const bool use_convergent_contact_formulation,
+			const json &barrier_stiffness,
+			const ipc::BroadPhaseMethod broad_phase,
+			const double ccd_tolerance,
+			const long ccd_max_iterations,
+
+			// Friction form
+			const double friction_coefficient,
+			const double epsv,
+			const int friction_iterations,
+
+			// Rayleigh damping form
+			const json &rayleigh_damping);
+
+		/// @brief update the barrier stiffness for the forms
+		/// @param x current solution
+		void update_barrier_stiffness(const Eigen::VectorXd &x);
+
+		/// @brief updates the dt inside the different forms
+		void update_dt();
+
+		std::unordered_map<std::string, std::shared_ptr<solver::Form>> named_forms() const;
+
+	public:
+		std::shared_ptr<assembler::RhsAssembler> rhs_assembler;
+		std::shared_ptr<solver::NLProblem> nl_problem;
+
+		std::shared_ptr<solver::ALForm> al_form;
+		std::shared_ptr<solver::BodyForm> body_form;
+		std::shared_ptr<solver::ContactForm> contact_form;
+		std::shared_ptr<solver::ElasticForm> damping_form;
+		std::shared_ptr<solver::ElasticForm> elastic_form;
+		std::shared_ptr<solver::FrictionForm> friction_form;
+		std::shared_ptr<solver::InertiaForm> inertia_form;
+
+		std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator;
+	};
+} // namespace polyfem::solver

--- a/src/polyfem/solver/SparseNewtonDescentSolver.hpp
+++ b/src/polyfem/solver/SparseNewtonDescentSolver.hpp
@@ -18,7 +18,7 @@ namespace cppoptlib
 		using typename Superclass::Scalar;
 		using typename Superclass::TVector;
 
-		SparseNewtonDescentSolver(const json &solver_params, const json &linear_solver_params);
+		SparseNewtonDescentSolver(const json &solver_params, const json &linear_solver_params, const double dt = 1.0);
 
 		std::string name() const override { return "Newton"; }
 

--- a/src/polyfem/solver/SparseNewtonDescentSolver.hpp
+++ b/src/polyfem/solver/SparseNewtonDescentSolver.hpp
@@ -18,7 +18,7 @@ namespace cppoptlib
 		using typename Superclass::Scalar;
 		using typename Superclass::TVector;
 
-		SparseNewtonDescentSolver(const json &solver_params, const json &linear_solver_params, const double dt = 1.0);
+		SparseNewtonDescentSolver(const json &solver_params, const json &linear_solver_params, const double dt);
 
 		std::string name() const override { return "Newton"; }
 

--- a/src/polyfem/solver/SparseNewtonDescentSolver.tpp
+++ b/src/polyfem/solver/SparseNewtonDescentSolver.tpp
@@ -6,8 +6,8 @@ namespace cppoptlib
 {
 	template <typename ProblemType>
 	SparseNewtonDescentSolver<ProblemType>::SparseNewtonDescentSolver(
-		const json &solver_params, const json &linear_solver_params)
-		: Superclass(solver_params)
+		const json &solver_params, const json &linear_solver_params, const double dt)
+		: Superclass(solver_params, dt)
 	{
 		linear_solver = polysolve::LinearSolver::create(
 			linear_solver_params["solver"], linear_solver_params["precond"]);

--- a/src/polyfem/solver/forms/ALForm.cpp
+++ b/src/polyfem/solver/forms/ALForm.cpp
@@ -15,13 +15,37 @@ namespace polyfem::solver
 				   const bool is_time_dependent,
 				   const double t)
 		: boundary_nodes_(boundary_nodes),
-		  local_boundary_(local_boundary),
-		  local_neumann_boundary_(local_neumann_boundary),
+		  local_boundary_(&local_boundary),
+		  local_neumann_boundary_(&local_neumann_boundary),
 		  n_boundary_samples_(n_boundary_samples),
-		  rhs_assembler_(rhs_assembler),
+		  rhs_assembler_(&rhs_assembler),
 		  is_time_dependent_(is_time_dependent)
 	{
+		init_masked_lumped_mass(ndof, mass, obstacle);
+		update_target(t); // initialize target_x_
+	}
 
+	ALForm::ALForm(const int ndof,
+				   const std::vector<int> &boundary_nodes,
+				   const StiffnessMatrix &mass,
+				   const mesh::Obstacle &obstacle,
+				   const Eigen::MatrixXd &target_x)
+		: boundary_nodes_(boundary_nodes),
+		  local_boundary_(nullptr),
+		  local_neumann_boundary_(nullptr),
+		  n_boundary_samples_(0),
+		  rhs_assembler_(nullptr),
+		  is_time_dependent_(false),
+		  target_x_(target_x)
+	{
+		init_masked_lumped_mass(ndof, mass, obstacle);
+	}
+
+	void ALForm::init_masked_lumped_mass(
+		const int ndof,
+		const StiffnessMatrix &mass,
+		const mesh::Obstacle &obstacle)
+	{
 		std::vector<bool> is_boundary_dof(ndof, true);
 		for (const auto bn : boundary_nodes_)
 			is_boundary_dof[bn] = false;
@@ -45,8 +69,6 @@ namespace polyfem::solver
 			assert(row == col); // matrix should be diagonal
 			return !is_boundary_dof[row];
 		});
-
-		update_target(t);
 	}
 
 	double ALForm::value_unweighted(const Eigen::VectorXd &x) const
@@ -82,7 +104,12 @@ namespace polyfem::solver
 
 	void ALForm::update_target(const double t)
 	{
+		assert(rhs_assembler_ != nullptr);
+		assert(local_boundary_ != nullptr);
+		assert(local_neumann_boundary_ != nullptr);
 		target_x_.setZero(masked_lumped_mass_.rows(), 1);
-		rhs_assembler_.set_bc(local_boundary_, boundary_nodes_, n_boundary_samples_, local_neumann_boundary_, target_x_, Eigen::MatrixXd(), t);
+		rhs_assembler_->set_bc(
+			*local_boundary_, boundary_nodes_, n_boundary_samples_,
+			*local_neumann_boundary_, target_x_, Eigen::MatrixXd(), t);
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/ALForm.hpp
+++ b/src/polyfem/solver/forms/ALForm.hpp
@@ -15,10 +15,17 @@ namespace polyfem::solver
 	class ALForm : public Form
 	{
 	public:
-		/// @brief Construct a new AL Form object
-		/// @param state Reference to the simulation state
-		/// @param rhs_assembler Reference to the right hand side assembler
-		/// @param t current time
+		/// @brief Construct a new ALForm object with a time dependent Dirichlet boundary
+		/// @param ndof Number of degrees of freedom
+		/// @param boundary_nodes DoFs that are part of the Dirichlet boundary
+		/// @param local_boundary
+		/// @param local_neumann_boundary
+		/// @param n_boundary_samples
+		/// @param mass Mass matrix
+		/// @param rhs_assembler Right hand side assembler
+		/// @param obstacle Obstacles
+		/// @param is_time_dependent Whether the problem is time dependent
+		/// @param t Current time
 		ALForm(const int ndof,
 			   const std::vector<int> &boundary_nodes,
 			   const std::vector<mesh::LocalBoundary> &local_boundary,
@@ -30,7 +37,18 @@ namespace polyfem::solver
 			   const bool is_time_dependent,
 			   const double t);
 
-	protected:
+		/// @brief Construct a new ALForm object with a fixed Dirichlet boundary
+		/// @param ndof Number of degrees of freedom
+		/// @param boundary_nodes DoFs that are part of the Dirichlet boundary
+		/// @param mass Mass matrix
+		/// @param obstacle Obstacles
+		/// @param target_x Target values for the boundary DoFs
+		ALForm(const int ndof,
+			   const std::vector<int> &boundary_nodes,
+			   const StiffnessMatrix &mass,
+			   const mesh::Obstacle &obstacle,
+			   const Eigen::MatrixXd &target_x);
+
 		/// @brief Compute the value of the form
 		/// @param x Current solution
 		/// @return Computed value
@@ -54,16 +72,27 @@ namespace polyfem::solver
 
 	private:
 		const std::vector<int> &boundary_nodes_;
-		const std::vector<mesh::LocalBoundary> &local_boundary_;
-		const std::vector<mesh::LocalBoundary> &local_neumann_boundary_;
+		const std::vector<mesh::LocalBoundary> *local_boundary_;
+		const std::vector<mesh::LocalBoundary> *local_neumann_boundary_;
 		const int n_boundary_samples_;
 
-		const assembler::RhsAssembler &rhs_assembler_; ///< Reference to the RHS assembler
+		const assembler::RhsAssembler *rhs_assembler_; ///< Reference to the RHS assembler
 		const bool is_time_dependent_;
 
 		StiffnessMatrix masked_lumped_mass_; ///< mass matrix masked by the AL dofs
 		Eigen::MatrixXd target_x_;           ///< actually a vector with the same size as x with target nodal positions
 
+		/// @brief Initialize the masked lumped mass matrix
+		/// @param ndof Number of degrees of freedom
+		/// @param mass Mass matrix
+		/// @param obstacle Obstacles
+		void init_masked_lumped_mass(
+			const int ndof,
+			const StiffnessMatrix &mass,
+			const mesh::Obstacle &obstacle);
+
+		/// @brief Update target x to the Dirichlet boundary values at time t
+		/// @param t Current time
 		void update_target(const double t);
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/FrictionForm.hpp
+++ b/src/polyfem/solver/forms/FrictionForm.hpp
@@ -17,18 +17,16 @@ namespace polyfem::solver
 	{
 	public:
 		/// @brief Construct a new Friction Form object
-		/// @param state Reference to the simulation state
+		/// @param collision_mesh Reference to the collision mesh
 		/// @param epsv Smoothing factor between static and dynamic friction
 		/// @param mu Global coefficient of friction
 		/// @param dhat Barrier activation distance
-		/// @param barrier_stiffness Barrier stiffness multiplier
 		/// @param broad_phase_method Broad-phase method used for distance computation and collision detection
 		/// @param dt Time step size
 		/// @param contact_form Pointer to contact form; necessary to have the barrier stiffnes, maybe clean me
 		/// @param n_lagging_iters Number of lagging iterations
 		FrictionForm(
 			const ipc::CollisionMesh &collision_mesh,
-			const Eigen::MatrixXd &boundary_nodes_pos,
 			const double epsv,
 			const double mu,
 			const double dhat,
@@ -62,6 +60,10 @@ namespace polyfem::solver
 		/// @param x Current solution
 		void update_lagging(const Eigen::VectorXd &x, const int iter_num) override;
 
+		/// @brief Update lagged fields
+		/// @param x Current solution
+		void update_lagging(const Eigen::VectorXd &x) { update_lagging(x, -1); };
+
 		/// @brief Get the maximum number of lagging iteration allowable.
 		int max_lagging_iterations() const override { return n_lagging_iters_; }
 
@@ -73,7 +75,6 @@ namespace polyfem::solver
 
 	private:
 		const ipc::CollisionMesh &collision_mesh_;
-		const Eigen::MatrixXd &boundary_nodes_pos_;
 
 		const double epsv_;                              ///< Smoothing factor between static and dynamic friction
 		const double mu_;                                ///< Global coefficient of friction

--- a/src/polyfem/solver/line_search/BacktrackingLineSearch.hpp
+++ b/src/polyfem/solver/line_search/BacktrackingLineSearch.hpp
@@ -189,6 +189,11 @@ namespace polyfem
 							"Line search failed to find descent step (f(x)={:g} f(x+αΔx)={:g} α_CCD={:g} α={:g}, ||Δx||={:g} is_step_valid={} use_grad_norm={} iter={:d})",
 							old_energy, cur_energy, starting_step_size, step_size, delta_x.norm(),
 							is_step_valid, use_grad_norm, this->cur_iter);
+#ifndef NDEBUG
+						objFunc.solution_changed(x);
+						// tolerance for rounding error due to multithreading
+						assert(abs(old_energy_in - objFunc.value(x)) < 1e-15);
+#endif
 						objFunc.line_search_end();
 						return std::nan("");
 					}

--- a/src/polyfem/state/StateInit.cpp
+++ b/src/polyfem/state/StateInit.cpp
@@ -218,6 +218,14 @@ namespace polyfem
 			}
 		}
 
+		// Save output directory and resolve output paths dynamically
+		const std::string output_dir = this->args["output"]["directory"];
+		if (!output_dir.empty())
+		{
+			std::filesystem::create_directories(output_dir);
+		}
+		this->output_dir = output_dir;
+
 		std::string out_path_log = this->args["output"]["log"]["path"];
 		if (!out_path_log.empty())
 		{
@@ -294,14 +302,6 @@ namespace polyfem
 			// important for the BC
 			problem->set_parameters(args["preset_problem"]);
 		}
-
-		// Save output directory and resolve output paths dynamically
-		const std::string output_dir = this->args["output"]["directory"];
-		if (!output_dir.empty())
-		{
-			std::filesystem::create_directories(output_dir);
-		}
-		this->output_dir = output_dir;
 	}
 
 	void State::set_max_threads(const unsigned int max_threads)

--- a/src/polyfem/state/StateOutput.cpp
+++ b/src/polyfem/state/StateOutput.cpp
@@ -177,4 +177,57 @@ namespace polyfem
 			mises_path,
 			is_contact_enabled(), solution_frames);
 	}
+
+	void State::save_restart_json(const double t0, const double dt, const int t) const
+	{
+		const std::string restart_json_path = args["output"]["restart_json"];
+		if (restart_json_path.empty())
+			return;
+
+		json restart_json;
+		restart_json["root_path"] = root_path();
+		restart_json["common"] = root_path();
+		restart_json["time"] = {{"t0", t0 + dt * t}};
+
+		const std::string rest_mesh_path = args["output"]["data"]["rest_mesh"].get<std::string>();
+		if (!rest_mesh_path.empty())
+		{
+			std::vector<json> patch;
+			const std::vector<json> in_geometry = args["geometry"];
+			for (int i = 0; i < in_geometry.size(); ++i)
+			{
+				if (!in_geometry[i]["is_obstacle"].get<bool>())
+				{
+					patch.push_back({
+						{"op", "remove"},
+						{"path", fmt::format("/geometry/{}", i)},
+					});
+				}
+			}
+			const int remaining_geometry = in_geometry.size() - patch.size();
+			assert(remaining_geometry >= 0);
+			patch.push_back({
+				{"op", "add"},
+				{"path", fmt::format("/geometry/{}", remaining_geometry > 0 ? "0" : "-")},
+				{"value",
+				 {
+					 // TODO: this does not set the surface selections
+					 {"mesh", resolve_output_path(fmt::format(args["output"]["data"]["rest_mesh"], t))},
+				 }},
+			});
+			restart_json["patch"] = patch;
+		}
+
+		restart_json["input"] = {{
+			"data",
+			{
+				{"u_path", resolve_output_path(fmt::format(args["output"]["data"]["u_path"], t))},
+				{"v_path", resolve_output_path(fmt::format(args["output"]["data"]["v_path"], t))},
+				{"a_path", resolve_output_path(fmt::format(args["output"]["data"]["a_path"], t))},
+			},
+		}};
+
+		std::ofstream file(resolve_output_path(fmt::format(restart_json_path, t)));
+		file << restart_json;
+	}
 } // namespace polyfem

--- a/src/polyfem/state/StateSolve.cpp
+++ b/src/polyfem/state/StateSolve.cpp
@@ -39,7 +39,18 @@ namespace polyfem
 		assert(solve_data.rhs_assembler != nullptr);
 		const std::string in_path = resolve_input_path(args["input"]["data"]["u_path"]);
 		if (!in_path.empty())
-			import_matrix(in_path, args["import"], solution);
+		{
+			if (!read_matrix(in_path, solution))
+				log_and_throw_error("Unable to read initial solution from file ({})!", in_path);
+			assert(solution.cols() == 1);
+			if (args["input"]["data"]["reorder"].get<bool>())
+			{
+				const int ndof = in_node_to_node.size() * mesh->dimension();
+				assert(ndof + obstacle.ndof() == solution.size());
+				// only reorder the first ndof rows
+				solution.topRows(ndof) = utils::reorder_matrix(solution.topRows(ndof), in_node_to_node, -1, mesh->dimension());
+			}
+		}
 		else
 		{
 			if (problem->is_time_dependent())
@@ -57,7 +68,18 @@ namespace polyfem
 		assert(solve_data.rhs_assembler != nullptr);
 		const std::string in_path = resolve_input_path(args["input"]["data"]["v_path"]);
 		if (!in_path.empty())
-			import_matrix(in_path, args["import"], velocity);
+		{
+			if (!read_matrix(in_path, velocity))
+				log_and_throw_error("Unable to read initial velocity from file ({})!", in_path);
+			assert(velocity.cols() == 1);
+			if (args["input"]["data"]["reorder"].get<bool>())
+			{
+				const int ndof = in_node_to_node.size() * mesh->dimension();
+				assert(ndof + obstacle.ndof() == velocity.size());
+				// only reorder the first ndof rows
+				velocity.topRows(ndof) = utils::reorder_matrix(velocity.topRows(ndof), in_node_to_node, -1, mesh->dimension());
+			}
+		}
 		else
 			solve_data.rhs_assembler->initial_velocity(velocity);
 	}
@@ -67,7 +89,18 @@ namespace polyfem
 		assert(solve_data.rhs_assembler != nullptr);
 		const std::string in_path = resolve_input_path(args["input"]["data"]["a_path"]);
 		if (!in_path.empty())
-			import_matrix(in_path, args["import"], acceleration);
+		{
+			if (!read_matrix(in_path, acceleration))
+				log_and_throw_error("Unable to read initial acceleration from file ({})!", in_path);
+			if (args["input"]["data"]["reorder"].get<bool>())
+			{
+				assert(acceleration.cols() == 1);
+				const int ndof = in_node_to_node.size() * mesh->dimension();
+				assert(ndof + obstacle.ndof() == acceleration.size());
+				// only reorder the first ndof rows
+				acceleration.topRows(ndof) = utils::reorder_matrix(acceleration.topRows(ndof), in_node_to_node, -1, mesh->dimension());
+			}
+		}
 		else
 			solve_data.rhs_assembler->initial_acceleration(acceleration);
 	}

--- a/src/polyfem/state/StateSolveNonlinear.cpp
+++ b/src/polyfem/state/StateSolveNonlinear.cpp
@@ -186,7 +186,6 @@ namespace polyfem
 		// Initialize nonlinear problems
 
 		const int ndof = n_bases * mesh->dimension();
-		logger().critical("# DOF: {}", ndof);
 		solve_data.nl_problem = std::make_shared<NLProblem>(
 			ndof, boundary_nodes, local_boundary, n_boundary_samples(),
 			*solve_data.rhs_assembler, t, forms);

--- a/src/polyfem/state/StateSolveNonlinear.cpp
+++ b/src/polyfem/state/StateSolveNonlinear.cpp
@@ -14,6 +14,8 @@
 #include <polyfem/solver/SparseNewtonDescentSolver.hpp>
 #include <polyfem/solver/NLProblem.hpp>
 #include <polyfem/solver/ALSolver.hpp>
+#include <polyfem/solver/SolveData.hpp>
+#include <polyfem/io/MshWriter.hpp>
 #include <polyfem/io/OBJWriter.hpp>
 #include <polyfem/utils/MatrixUtils.hpp>
 #include <polyfem/utils/Timer.hpp>
@@ -21,90 +23,31 @@
 
 #include <ipc/ipc.hpp>
 
-// map BroadPhaseMethod values to JSON as strings
-namespace ipc
-{
-	NLOHMANN_JSON_SERIALIZE_ENUM(
-		ipc::BroadPhaseMethod,
-		{{ipc::BroadPhaseMethod::HASH_GRID, "hash_grid"}, // also default
-		 {ipc::BroadPhaseMethod::HASH_GRID, "HG"},
-		 {ipc::BroadPhaseMethod::BRUTE_FORCE, "brute_force"},
-		 {ipc::BroadPhaseMethod::BRUTE_FORCE, "BF"},
-		 {ipc::BroadPhaseMethod::SPATIAL_HASH, "spatial_hash"},
-		 {ipc::BroadPhaseMethod::SPATIAL_HASH, "SH"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "sweep_and_tiniest_queue"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "STQ"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "sweep_and_tiniest_queue_gpu"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "STQ_GPU"}})
-} // namespace ipc
-
 namespace polyfem
 {
+	using namespace mesh;
 	using namespace solver;
+	using namespace time_integrator;
 	using namespace io;
 	using namespace utils;
 
-	void SolveData::update_barrier_stiffness(const Eigen::VectorXd &x)
-	{
-		// TODO: missing use_adaptive_barrier_stiffness_ if (use_adaptive_barrier_stiffness_ && is_time_dependent_)
-		// if (inertia_form == nullptr)
-		// 	return;
-
-		// if (contact_form)
-		// 	contact_form->update_barrier_stiffness(x, *nl_problem, friction_form);
-
-		if (contact_form == nullptr)
-			return;
-
-		if (!contact_form->use_adaptive_barrier_stiffness())
-			return;
-
-		Eigen::VectorXd grad_energy(x.size(), 1);
-		grad_energy.setZero();
-
-		elastic_form->first_derivative(x, grad_energy);
-
-		if (inertia_form)
-		{
-			Eigen::VectorXd grad_inertia(x.size());
-			inertia_form->first_derivative(x, grad_inertia);
-			grad_energy += grad_inertia;
-		}
-
-		Eigen::VectorXd body_energy(x.size());
-		body_form->first_derivative(x, body_energy);
-		grad_energy += body_energy;
-
-		contact_form->update_barrier_stiffness(x, grad_energy);
-	}
-
-	void SolveData::update_dt()
-	{
-		if (inertia_form)
-		{
-			elastic_form->set_weight(time_integrator->acceleration_scaling());
-			body_form->set_weight(time_integrator->acceleration_scaling());
-			if (damping_form)
-				damping_form->set_weight(time_integrator->acceleration_scaling());
-
-			// TODO: Determine if friction should be scaled by h²
-			// if (friction_form)
-			// 	friction_form->set_weight(time_integrator->acceleration_scaling());
-		}
-	}
-
 	template <typename ProblemType>
-	std::shared_ptr<cppoptlib::NonlinearSolver<ProblemType>> State::make_nl_solver() const
+	std::shared_ptr<cppoptlib::NonlinearSolver<ProblemType>> State::make_nl_solver(
+		const std::string &linear_solver_type) const
 	{
 		const std::string name = args["solver"]["nonlinear"]["solver"];
+		const double dt = problem->is_time_dependent() ? args["time"]["dt"].get<double>() : 1.0;
 		if (name == "newton" || name == "Newton")
 		{
+			json linear_solver_params = args["solver"]["linear"];
+			if (!linear_solver_type.empty())
+				linear_solver_params["solver"] = linear_solver_type;
 			return std::make_shared<cppoptlib::SparseNewtonDescentSolver<ProblemType>>(
-				args["solver"]["nonlinear"], args["solver"]["linear"]);
+				args["solver"]["nonlinear"], linear_solver_params, dt);
 		}
 		else if (name == "lbfgs" || name == "LBFGS" || name == "L-BFGS")
 		{
-			return std::make_shared<cppoptlib::LBFGSSolver<ProblemType>>(args["solver"]["nonlinear"]);
+			return std::make_shared<cppoptlib::LBFGSSolver<ProblemType>>(args["solver"]["nonlinear"], dt);
 		}
 		else
 		{
@@ -136,21 +79,35 @@ namespace polyfem
 			save_timestep(t0 + dt * t, t, t0, dt, sol, Eigen::MatrixXd()); // no pressure
 
 			logger().info("{}/{}  t={}", t, time_steps, t0 + dt * t);
-		}
 
-		solve_data.time_integrator->save_raw(
-			resolve_output_path(args["output"]["data"]["u_path"]),
-			resolve_output_path(args["output"]["data"]["v_path"]),
-			resolve_output_path(args["output"]["data"]["a_path"]));
+			const std::string rest_mesh_path = args["output"]["data"]["rest_mesh"].get<std::string>();
+			if (!rest_mesh_path.empty())
+			{
+				Eigen::MatrixXd V;
+				Eigen::MatrixXi F;
+				build_mesh_matrices(V, F);
+				io::MshWriter::write(
+					resolve_output_path(fmt::format(args["output"]["data"]["rest_mesh"], t)),
+					V, F, mesh->get_body_ids(), mesh->is_volume(), /*binary=*/true);
+			}
+
+			solve_data.time_integrator->save_raw(
+				resolve_output_path(fmt::format(args["output"]["data"]["u_path"], t)),
+				resolve_output_path(fmt::format(args["output"]["data"]["v_path"], t)),
+				resolve_output_path(fmt::format(args["output"]["data"]["a_path"], t)));
+
+			// save restart file
+			save_restart_json(t0, dt, t);
+		}
 	}
 
-	void State::init_nonlinear_tensor_solve(Eigen::MatrixXd &sol, const double t)
+	void State::init_nonlinear_tensor_solve(Eigen::MatrixXd &sol, const double t, const bool init_time_integrator)
 	{
 		assert(!assembler.is_linear(formulation()) || is_contact_enabled()); // non-linear
 		assert(!problem->is_scalar());                                       // tensor
 		assert(!assembler.is_mixed(formulation()));
 
-		///////////////////////////////////////////////////////////////////////
+		// --------------------------------------------------------------------
 		// Check for initial intersections
 		if (is_contact_enabled())
 		{
@@ -168,179 +125,79 @@ namespace polyfem
 			}
 		}
 
-		const int ndof = n_bases * mesh->dimension();
-		// if (is_formulation_mixed) //mixed not supported
-		// 	ndof_ += n_pressure_bases; // Pressure is a scalar
-
-		assert(solve_data.rhs_assembler != nullptr);
-
-		std::vector<std::shared_ptr<Form>> forms;
-		solve_data.elastic_form = std::make_shared<ElasticForm>(
-			n_bases, bases, geom_bases(),
-			assembler, ass_vals_cache,
-			formulation(),
-			problem->is_time_dependent() ? args["time"]["dt"].get<double>() : 0.0,
-			mesh->is_volume());
-		forms.push_back(solve_data.elastic_form);
-
-		solve_data.body_form = std::make_shared<BodyForm>(
-			ndof, n_pressure_bases,
-			boundary_nodes, local_boundary, local_neumann_boundary, n_boundary_samples(),
-			rhs, *solve_data.rhs_assembler,
-			assembler.density(),
-			/*apply_DBC=*/true, /*is_formulation_mixed=*/false, problem->is_time_dependent());
-		solve_data.body_form->update_quantities(t, sol);
-		forms.push_back(solve_data.body_form);
-
-		solve_data.inertia_form = nullptr;
-		solve_data.damping_form = nullptr;
-		if (problem->is_time_dependent())
-		{
-			solve_data.time_integrator = time_integrator::ImplicitTimeIntegrator::construct_time_integrator(args["time"]["integrator"]);
-			if (!args["solver"]["ignore_inertia"])
-			{
-				solve_data.inertia_form = std::make_shared<InertiaForm>(mass, *solve_data.time_integrator);
-				forms.push_back(solve_data.inertia_form);
-			}
-			if (assembler.has_damping())
-			{
-				solve_data.damping_form = std::make_shared<ElasticForm>(
-					n_bases, bases, geom_bases(),
-					assembler, ass_vals_cache,
-					"Damping",
-					args["time"]["dt"],
-					mesh->is_volume());
-				forms.push_back(solve_data.damping_form);
-			}
-		}
-		else
-		{
-			const double lagged_regularization_weight = args["solver"]["advanced"]["lagged_regularization_weight"];
-			if (lagged_regularization_weight > 0)
-			{
-				forms.push_back(std::make_shared<LaggedRegForm>(args["solver"]["advanced"]["lagged_regularization_iterations"]));
-				forms.back()->set_weight(lagged_regularization_weight);
-			}
-		}
-
-		solve_data.al_form = std::make_shared<ALForm>(
-			ndof,
-			boundary_nodes, local_boundary, local_neumann_boundary, n_boundary_samples(),
-			mass,
-			*solve_data.rhs_assembler,
-			obstacle,
-			problem->is_time_dependent(),
-			t);
-		forms.push_back(solve_data.al_form);
-
-		solve_data.contact_form = nullptr;
-		solve_data.friction_form = nullptr;
-		if (args["contact"]["enabled"])
-		{
-
-			const bool use_adaptive_barrier_stiffness = !args["solver"]["contact"]["barrier_stiffness"].is_number();
-
-			solve_data.contact_form = std::make_shared<ContactForm>(
-				collision_mesh, boundary_nodes_pos,
-				args["contact"]["dhat"],
-				avg_mass,
-				use_adaptive_barrier_stiffness,
-				/*is_time_dependent=*/solve_data.time_integrator != nullptr,
-				args["solver"]["contact"]["CCD"]["broad_phase"],
-				args["solver"]["contact"]["CCD"]["tolerance"],
-				args["solver"]["contact"]["CCD"]["max_iterations"]);
-
-			if (use_adaptive_barrier_stiffness)
-			{
-				solve_data.contact_form->set_weight(1);
-				logger().debug("Using adaptive barrier stiffness");
-			}
-			else
-			{
-				solve_data.contact_form->set_weight(args["solver"]["contact"]["barrier_stiffness"]);
-				logger().debug("Using fixed barrier stiffness of {}", solve_data.contact_form->barrier_stiffness());
-			}
-
-			forms.push_back(solve_data.contact_form);
-
-			// ----------------------------------------------------------------
-
-			if (args["contact"]["friction_coefficient"].get<double>() != 0)
-			{
-				solve_data.friction_form = std::make_shared<FrictionForm>(
-					collision_mesh,
-					boundary_nodes_pos,
-					args["contact"]["epsv"],
-					args["contact"]["friction_coefficient"],
-					args["contact"]["dhat"],
-					args["solver"]["contact"]["CCD"]["broad_phase"],
-					args.value("/time/dt"_json_pointer, 1.0), // dt=1.0 if static
-					*solve_data.contact_form,
-					args["solver"]["contact"]["friction_iterations"]);
-				forms.push_back(solve_data.friction_form);
-			}
-		}
-
-		std::vector<json> rayleigh_damping_jsons;
-		if (args["solver"]["rayleigh_damping"].is_array())
-			rayleigh_damping_jsons = args["solver"]["rayleigh_damping"].get<std::vector<json>>();
-		else
-			rayleigh_damping_jsons.push_back(args["solver"]["rayleigh_damping"]);
-		if (problem->is_time_dependent())
-		{
-			// Map from form name to form so RayleighDampingForm::create can get the correct form to damp
-			const std::unordered_map<std::string, std::shared_ptr<Form>> possible_forms_to_damp = {
-				{"elasticity", solve_data.elastic_form},
-				{"contact", solve_data.contact_form},
-			};
-
-			for (const json &params : rayleigh_damping_jsons)
-			{
-				forms.push_back(RayleighDampingForm::create(
-					params, possible_forms_to_damp,
-					*solve_data.time_integrator));
-			}
-		}
-		else if (rayleigh_damping_jsons.size() > 0)
-		{
-			log_and_throw_error("Rayleigh damping is only supported for time-dependent problems");
-		}
-
-		///////////////////////////////////////////////////////////////////////
-		// Initialize nonlinear problems
-		solve_data.nl_problem = std::make_shared<NLProblem>(
-			ndof,
-			formulation(),
-			boundary_nodes,
-			local_boundary,
-			n_boundary_samples(),
-			*solve_data.rhs_assembler, t, forms);
-
-		///////////////////////////////////////////////////////////////////////
+		// --------------------------------------------------------------------
 		// Initialize time integrator
 		if (problem->is_time_dependent())
 		{
-			POLYFEM_SCOPED_TIMER("Initialize time integrator");
+			if (init_time_integrator)
+			{
+				POLYFEM_SCOPED_TIMER("Initialize time integrator");
+				solve_data.time_integrator = ImplicitTimeIntegrator::construct_time_integrator(args["time"]["integrator"]);
 
-			Eigen::MatrixXd velocity, acceleration;
-			initial_velocity(velocity);
-			assert(velocity.size() == sol.size());
-			initial_acceleration(acceleration);
-			assert(acceleration.size() == sol.size());
+				Eigen::MatrixXd velocity, acceleration;
+				initial_velocity(velocity);
+				assert(velocity.size() == sol.size());
+				initial_acceleration(acceleration);
+				assert(acceleration.size() == sol.size());
 
-			const double dt = args["time"]["dt"];
-			solve_data.time_integrator->init(sol, velocity, acceleration, dt);
+				const double dt = args["time"]["dt"];
+				solve_data.time_integrator->init(sol, velocity, acceleration, dt);
+			}
+			assert(solve_data.time_integrator != nullptr);
 		}
-		solve_data.update_dt();
+		else
+		{
+			solve_data.time_integrator = nullptr;
+		}
 
-		///////////////////////////////////////////////////////////////////////
+		// --------------------------------------------------------------------
+		// Initialize forms
+
+		const std::vector<std::shared_ptr<Form>> forms = solve_data.init_forms(
+			// General
+			mesh->dimension(), t,
+			// Elastic form
+			n_bases, bases, geom_bases(), assembler, ass_vals_cache, formulation(),
+			// Body form
+			n_pressure_bases, boundary_nodes, local_boundary, local_neumann_boundary,
+			n_boundary_samples(), rhs, sol,
+			// Inertia form
+			args["solver"]["ignore_inertia"], mass,
+			// Lagged regularization form
+			args["solver"]["advanced"]["lagged_regularization_weight"],
+			args["solver"]["advanced"]["lagged_regularization_iterations"],
+			// Augmented lagrangian form
+			obstacle,
+			// Contact form
+			args["contact"]["enabled"], collision_mesh, args["contact"]["dhat"],
+			avg_mass, args["contact"]["use_convergent_formulation"],
+			args["solver"]["contact"]["barrier_stiffness"],
+			args["solver"]["contact"]["CCD"]["broad_phase"],
+			args["solver"]["contact"]["CCD"]["tolerance"],
+			args["solver"]["contact"]["CCD"]["max_iterations"],
+			// Friction form
+			args["contact"]["friction_coefficient"],
+			args["contact"]["epsv"],
+			args["solver"]["contact"]["friction_iterations"],
+			// Rayleigh damping form
+			args["solver"]["rayleigh_damping"]);
+
+		// --------------------------------------------------------------------
+		// Initialize nonlinear problems
+
+		const int ndof = n_bases * mesh->dimension();
+		logger().critical("# DOF: {}", ndof);
+		solve_data.nl_problem = std::make_shared<NLProblem>(
+			ndof, boundary_nodes, local_boundary, n_boundary_samples(),
+			*solve_data.rhs_assembler, t, forms);
+
+		// --------------------------------------------------------------------
 
 		stats.solver_info = json::array();
 	}
 
-	void State::solve_tensor_nonlinear(Eigen::MatrixXd &sol, const int t)
+	void State::solve_tensor_nonlinear(Eigen::MatrixXd &sol, const int t, const bool init_lagging)
 	{
-
 		assert(solve_data.nl_problem != nullptr);
 		NLProblem &nl_problem = *(solve_data.nl_problem);
 
@@ -348,9 +205,12 @@ namespace polyfem
 
 		if (nl_problem.uses_lagging())
 		{
-			POLYFEM_SCOPED_TIMER("Initializing lagging");
-			nl_problem.init_lagging(sol);
-			logger().info("Lagging iteration {:d}:", 1);
+			if (init_lagging)
+			{
+				POLYFEM_SCOPED_TIMER("Initializing lagging");
+				nl_problem.init_lagging(sol); // TODO: this should be u_prev projected
+			}
+			logger().info("Lagging iteration 1:");
 		}
 
 		// ---------------------------------------------------------------------
@@ -384,6 +244,7 @@ namespace polyfem
 			save_subsolve(++subsolve_count, t, sol, Eigen::MatrixXd()); // no pressure
 		};
 
+		Eigen::MatrixXd prev_sol = sol;
 		al_solver.solve(nl_problem, sol, args["solver"]["augmented_lagrangian"]["force"]);
 
 		// ---------------------------------------------------------------------
@@ -403,13 +264,23 @@ namespace polyfem
 			// Check if lagging converged
 			Eigen::VectorXd grad;
 			nl_problem.gradient(tmp_sol, grad);
-			logger().debug("Lagging convergence grad_norm={:g} tol={:g}", grad.norm(), lagging_tol);
+			const double delta_x_norm = (prev_sol - sol).lpNorm<Eigen::Infinity>();
+			logger().debug("Lagging convergence grad_norm={:g} tol={:g} (||Δx||={:g})", grad.norm(), lagging_tol, delta_x_norm);
 			if (grad.norm() <= lagging_tol)
 			{
 				logger().info(
 					"Lagging converged in {:d} iteration(s) (grad_norm={:g} tol={:g})",
 					lag_i, grad.norm(), lagging_tol);
 				lagging_converged = true;
+				break;
+			}
+
+			if (delta_x_norm <= 1e-12)
+			{
+				logger().warn(
+					"Lagging produced tiny update between iterations {:d} and {:d} (grad_norm={:g} grad_tol={:g} ||Δx||={:g} Δx_tol={:g}); stopping early",
+					lag_i - 1, lag_i, grad.norm(), lagging_tol, delta_x_norm, 1e-6);
+				lagging_converged = false;
 				break;
 			}
 
@@ -428,6 +299,7 @@ namespace polyfem
 			nl_problem.init(sol);
 			solve_data.update_barrier_stiffness(sol);
 			nl_solver->minimize(nl_problem, tmp_sol);
+			prev_sol = sol;
 			sol = nl_problem.reduced_to_full(tmp_sol);
 
 			// Save the subsolve sequence for debugging and info
@@ -444,5 +316,5 @@ namespace polyfem
 
 	////////////////////////////////////////////////////////////////////////
 	// Template instantiations
-	template std::shared_ptr<cppoptlib::NonlinearSolver<NLProblem>> State::make_nl_solver() const;
+	template std::shared_ptr<cppoptlib::NonlinearSolver<NLProblem>> State::make_nl_solver(const std::string &) const;
 } // namespace polyfem

--- a/src/polyfem/time_integrator/BDF.hpp
+++ b/src/polyfem/time_integrator/BDF.hpp
@@ -19,7 +19,7 @@ namespace polyfem::time_integrator
 		/// @param params json containing `{"steps": 1}`
 		void set_parameters(const json &params) override;
 
-		/// @brief Update the time integration quantaties (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
+		/// @brief Update the time integration quantities (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
 		/// @param x new solution vector
 		void update_quantities(const Eigen::VectorXd &x) override;
 

--- a/src/polyfem/time_integrator/ImplicitEuler.hpp
+++ b/src/polyfem/time_integrator/ImplicitEuler.hpp
@@ -15,7 +15,7 @@ namespace polyfem::time_integrator
 	public:
 		ImplicitEuler() {}
 
-		/// @brief Update the time integration quantaties (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
+		/// @brief Update the time integration quantities (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
 		/// \f[
 		/// 	v^{t+1} = \frac{1}{\Delta t} (x - x^t)\newline
 		/// 	a^{t+1} = \frac{1}{\Delta t} (v - v^t)

--- a/src/polyfem/time_integrator/ImplicitNewmark.hpp
+++ b/src/polyfem/time_integrator/ImplicitNewmark.hpp
@@ -19,7 +19,7 @@ namespace polyfem::time_integrator
 		/// @param params json containing `{"gamma": 0.5, "beta": 0.25}`
 		void set_parameters(const json &params) override;
 
-		/// @brief Update the time integration quantaties (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
+		/// @brief Update the time integration quantities (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
 		/// @param x new solution vector
 		void update_quantities(const Eigen::VectorXd &x) override;
 

--- a/src/polyfem/time_integrator/ImplicitTimeIntegrator.hpp
+++ b/src/polyfem/time_integrator/ImplicitTimeIntegrator.hpp
@@ -39,7 +39,7 @@ namespace polyfem::time_integrator
 			const std::vector<Eigen::VectorXd> &a_prevs,
 			double dt);
 
-		/// @brief Update the time integration quantaties (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
+		/// @brief Update the time integration quantities (i.e., \f$x\f$, \f$v\f$, and \f$a\f$).
 		/// @param x new solution vector
 		virtual void update_quantities(const Eigen::VectorXd &x) = 0;
 

--- a/src/polyfem/utils/CMakeLists.txt
+++ b/src/polyfem/utils/CMakeLists.txt
@@ -6,24 +6,28 @@ set(SOURCES
 	Bessel.hpp
 	BoundarySampler.cpp
 	BoundarySampler.hpp
-	Selection.cpp
-	Selection.hpp
+	ClipperUtils.cpp
+	ClipperUtils.hpp
 	DisableWarnings.hpp
 	EdgeSampler.cpp
 	EdgeSampler.hpp
 	ElasticityUtils.cpp
 	ElasticityUtils.hpp
 	EnableWarnings.hpp
+	ExpressionValue.cpp
+	ExpressionValue.hpp
+	GeometryUtils.cpp
+	GeometryUtils.hpp
 	getRSS.c
 	HashUtils.hpp
-	Logger.cpp
-	Logger.hpp
 	InterpolatedFunction.cpp
 	InterpolatedFunction.hpp
 	Interpolation.cpp
 	Interpolation.hpp
 	JSONUtils.cpp
 	JSONUtils.hpp
+	Logger.cpp
+	Logger.hpp
 	MatrixUtils.cpp
 	MatrixUtils.hpp
 	MaybeParallelFor.hpp
@@ -36,10 +40,10 @@ set(SOURCES
 	RBFInterpolation.hpp
 	RefElementSampler.cpp
 	RefElementSampler.hpp
+	Selection.cpp
+	Selection.hpp
 	StringUtils.cpp
 	StringUtils.hpp
-	ExpressionValue.cpp
-	ExpressionValue.hpp
 	Timer.hpp
 	Types.hpp
 )

--- a/src/polyfem/utils/ClipperUtils.cpp
+++ b/src/polyfem/utils/ClipperUtils.cpp
@@ -1,0 +1,93 @@
+#include "ClipperUtils.hpp"
+
+#ifdef POLYFEM_WITH_CLIPPER
+
+#include <polyfem/utils/GeometryUtils.hpp>
+
+namespace polyfem::utils
+{
+	std::vector<Eigen::MatrixXd> PolygonClipping::clip(
+		const Eigen::MatrixXd &subject_polygon,
+		const Eigen::MatrixXd &clipping_polygon)
+	{
+		using namespace ClipperLib;
+
+		Clipper clipper;
+
+		clipper.AddPath(toClipperPolygon(subject_polygon), ptSubject, /*closed=*/true);
+		clipper.AddPath(toClipperPolygon(clipping_polygon), ptClip, /*closed=*/true);
+
+		Paths solution;
+		clipper.Execute(ctIntersection, solution, pftNonZero, pftNonZero);
+
+		std::vector<Eigen::MatrixXd> result;
+		result.reserve(solution.size());
+		for (const auto &path : solution)
+		{
+			result.push_back(fromClipperPolygon(path));
+		}
+
+		return result;
+	}
+
+	std::vector<Eigen::MatrixXd> TriangleClipping::clip(
+		const Eigen::MatrixXd &subject_triangle,
+		const Eigen::MatrixXd &clipping_triangle)
+	{
+		const std::vector<Eigen::MatrixXd> overlap =
+			PolygonClipping::clip(
+				triangle_to_clockwise_order(subject_triangle),
+				triangle_to_clockwise_order(clipping_triangle));
+		assert(overlap.size() <= 1);
+
+		if (overlap.empty() || overlap[0].rows() < 3)
+			return std::vector<Eigen::MatrixXd>();
+
+		return triangle_fan(overlap[0]);
+	}
+
+	namespace
+	{
+		double scale_double_coord(double coord)
+		{
+			return coord * (double)DOUBLE_TO_INT_SCALE_FACTOR;
+		}
+	} // namespace
+
+	ClipperLib::IntPoint PolygonClipping::toClipperPoint(const Eigen::RowVector2d &p)
+	{
+		ClipperLib::IntPoint r;
+		assert(abs(scale_double_coord(p.x())) <= ClipperLib::hiRange);
+		r.X = (ClipperLib::cInt)std::round(scale_double_coord(p.x()));
+		assert(abs(scale_double_coord(p.y())) <= ClipperLib::hiRange);
+		r.Y = (ClipperLib::cInt)std::round(scale_double_coord(p.y()));
+		return r;
+	}
+
+	Eigen::RowVector2d PolygonClipping::fromClipperPoint(const ClipperLib::IntPoint &p)
+	{
+		return Eigen::RowVector2d(p.X, p.Y) / DOUBLE_TO_INT_SCALE_FACTOR;
+	}
+
+	ClipperLib::Path PolygonClipping::toClipperPolygon(const Eigen::MatrixXd &V)
+	{
+		ClipperLib::Path path(V.rows());
+		for (size_t i = 0; i < path.size(); ++i)
+		{
+			path[i] = toClipperPoint(V.row(i));
+		}
+		return path;
+	}
+
+	Eigen::MatrixXd PolygonClipping::fromClipperPolygon(const ClipperLib::Path &path)
+	{
+		Eigen::MatrixXd V(path.size(), 2);
+		for (size_t i = 0; i < path.size(); ++i)
+		{
+			V.row(i) = fromClipperPoint(path[i]);
+		}
+		return V;
+	}
+} // namespace polyfem::utils
+
+#endif

--- a/src/polyfem/utils/ClipperUtils.hpp
+++ b/src/polyfem/utils/ClipperUtils.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#ifdef POLYFEM_WITH_CLIPPER
+
+#include <Eigen/Core>
+#include <clipper.hpp>
+namespace polyfem::utils
+{
+	/// @brief Multiplicative scale factor when converting from double to integer coordinates.
+	static constexpr int64_t DOUBLE_TO_INT_SCALE_FACTOR = 1l << 51;
+
+	class PolygonClipping
+	{
+	public:
+		PolygonClipping() = delete;
+
+		/// @brief Clip a polygon using convex polygon.
+		/// @param[in] subject_polygon Polygon to clip in clockwise order.
+		/// @param[in] clipping_polygon Convex polygon to clip with in clockwise order.
+		/// @return Clipped polygon(s).
+		static std::vector<Eigen::MatrixXd> clip(
+			const Eigen::MatrixXd &subject_polygon,
+			const Eigen::MatrixXd &clipping_polygon);
+
+		static ClipperLib::IntPoint toClipperPoint(const Eigen::RowVector2d &p);
+		static Eigen::RowVector2d fromClipperPoint(const ClipperLib::IntPoint &p);
+
+		static ClipperLib::Path toClipperPolygon(const Eigen::MatrixXd &V);
+		static Eigen::MatrixXd fromClipperPolygon(const ClipperLib::Path &path);
+	};
+
+	class TriangleClipping
+	{
+	public:
+		TriangleClipping() = delete;
+
+		/// @brief Clip a triangle using triangle.
+		/// @param[in] subject_triangle Triangle to clip.
+		/// @param[in] clipping_triangle Triangle to clip with.
+		/// @return Clipped polygon(s).
+		/// @return Triangularization of the clipped (convex) polygon. Each entry is a matrix of size 3×2 containing the three vertices of each triangle.
+		static std::vector<Eigen::MatrixXd> clip(
+			const Eigen::MatrixXd &subject_triangle,
+			const Eigen::MatrixXd &clipping_triangle);
+	};
+
+} // namespace polyfem::utils
+
+#endif

--- a/src/polyfem/utils/GeometryUtils.cpp
+++ b/src/polyfem/utils/GeometryUtils.cpp
@@ -1,0 +1,499 @@
+#include "GeometryUtils.hpp"
+
+#include <polyfem/utils/Logger.hpp>
+
+#include <Eigen/Geometry>
+
+#include <igl/barycentric_coordinates.h>
+
+#include <ipc/distance/point_edge.hpp>
+#include <ipc/distance/point_triangle.hpp>
+
+namespace polyfem::utils
+{
+	double triangle_area_2D(
+		const Eigen::Vector2d &a,
+		const Eigen::Vector2d &b,
+		const Eigen::Vector2d &c)
+	{
+		return ((b.x() - a.x()) * (c.y() - a.y()) - (c.x() - a.x()) * (b.y() - a.y())) / 2.0;
+	}
+
+	double triangle_area_3D(
+		const Eigen::Vector3d &a,
+		const Eigen::Vector3d &b,
+		const Eigen::Vector3d &c)
+	{
+		return (b - a).cross(c - a).norm() / 2.0;
+	}
+
+	double triangle_area(const Eigen::MatrixXd V)
+	{
+		assert(V.rows() == 3);
+		if (V.cols() == 2)
+		{
+			return triangle_area_2D(V.row(0), V.row(1), V.row(2));
+		}
+		else
+		{
+			return triangle_area_3D(V.row(0), V.row(1), V.row(2));
+		}
+	}
+
+	double tetrahedron_volume(
+		const Eigen::Vector3d &a,
+		const Eigen::Vector3d &b,
+		const Eigen::Vector3d &c,
+		const Eigen::Vector3d &d)
+	{
+		return (b - a).cross(c - a).dot(d - a) / 6.0;
+	}
+
+	double tetrahedron_volume(const Eigen::MatrixXd V)
+	{
+		assert(V.rows() == 4 && V.cols() == 3);
+		return tetrahedron_volume(V.row(0), V.row(1), V.row(2), V.row(3));
+	}
+
+	Eigen::MatrixXd triangle_to_clockwise_order(const Eigen::MatrixXd &triangle)
+	{
+		// Only works for 2D triangles.
+		assert(triangle.rows() == 3 && triangle.cols() == 2);
+
+		if (triangle_area(triangle) <= 0)
+			return triangle; // triangle aleady in clockwise order.
+
+		Eigen::Matrix<double, 3, 2> triangle_clockwise;
+		triangle_clockwise.row(0) = triangle.row(2);
+		triangle_clockwise.row(1) = triangle.row(1);
+		triangle_clockwise.row(2) = triangle.row(0);
+
+		return triangle_clockwise;
+	}
+
+	std::vector<Eigen::MatrixXd> triangle_fan(const Eigen::MatrixXd &convex_polygon)
+	{
+		assert(convex_polygon.rows() >= 3);
+		std::vector<Eigen::MatrixXd> triangles;
+		for (int i = 1; i < convex_polygon.rows() - 1; ++i)
+		{
+			triangles.emplace_back(3, convex_polygon.cols());
+			triangles.back().row(0) = convex_polygon.row(0);
+			triangles.back().row(1) = convex_polygon.row(i);
+			triangles.back().row(2) = convex_polygon.row(i + 1);
+		}
+		return triangles;
+	}
+
+	Eigen::VectorXd barycentric_coordinates(
+		const Eigen::VectorXd &p,
+		const Eigen::MatrixXd &V)
+	{
+		Eigen::MatrixXd A(p.size() + 1, p.size() + 1);
+		A.topRows(p.size()) = V.transpose();
+		A.bottomRows(1).setOnes();
+
+		Eigen::VectorXd rhs(p.size() + 1);
+		rhs.topRows(p.size()) = p;
+		rhs.bottomRows(1).setOnes();
+
+		// TODO: Can we use better than LU?
+		const Eigen::VectorXd bc = A.partialPivLu().solve(rhs);
+		assert((A * bc - rhs).norm() / rhs.norm() < 1e-12);
+
+		return bc;
+	}
+
+	bool triangle_intersects_disk(
+		const Eigen::Vector2d &t0,
+		const Eigen::Vector2d &t1,
+		const Eigen::Vector2d &t2,
+		const Eigen::Vector2d &center,
+		const double radius)
+	{
+		Eigen::RowVector3d bc;
+		igl::barycentric_coordinates(
+			center.transpose(), t0.transpose(), t1.transpose(), t2.transpose(),
+			bc);
+
+		if (bc.minCoeff() >= 0) // point is inside triangle
+		{
+			assert(bc.maxCoeff() <= 1 + 1e-12); // bc.sum() == 1
+			return true;
+		}
+
+		const std::array<std::array<const Eigen::Vector2d *, 2>, 3> edges = {{
+			{{&t0, &t1}},
+			{{&t1, &t2}},
+			{{&t2, &t0}},
+		}};
+
+		const double radius_sqr = radius * radius;
+
+		for (const auto &e : edges)
+			if (ipc::point_edge_distance(center, *e[0], *e[1]) <= radius_sqr)
+				return true;
+
+		return false;
+	}
+
+	bool tetrahedron_intersects_ball(
+		const Eigen::Vector3d &t0,
+		const Eigen::Vector3d &t1,
+		const Eigen::Vector3d &t2,
+		const Eigen::Vector3d &t3,
+		const Eigen::Vector3d &center,
+		const double radius)
+	{
+		Eigen::RowVector4d bc;
+		igl::barycentric_coordinates(
+			center.transpose(), t0.transpose(), t1.transpose(),
+			t2.transpose(), t3.transpose(), bc);
+
+		if (bc.minCoeff() >= 0)
+		{
+			assert(bc.maxCoeff() <= 1 + 1e-12); // bc.sum() == 1
+			return true;
+		}
+
+		const std::array<std::array<const Eigen::Vector3d *, 3>, 4> faces = {{
+			{{&t0, &t1, &t2}},
+			{{&t0, &t1, &t3}},
+			{{&t0, &t2, &t3}},
+			{{&t1, &t2, &t3}},
+		}};
+
+		const double radius_sqr = radius * radius;
+
+		for (const auto &f : faces)
+			if (ipc::point_triangle_distance(center, *f[0], *f[1], *f[2]) <= radius_sqr)
+				return true;
+
+		return false;
+	}
+
+	bool are_edges_collinear(
+		const Eigen::VectorXd &ea0,
+		const Eigen::VectorXd &ea1,
+		const Eigen::VectorXd &eb0,
+		const Eigen::VectorXd &eb1,
+		const double tol)
+	{
+		assert((ea0 - ea1).norm() != 0 && (eb1 - eb0).norm() != 0);
+		const Eigen::VectorXd ea = (ea1 - ea0).normalized();
+		const Eigen::VectorXd eb = (eb1 - eb0).normalized();
+		return abs(ea.dot(eb)) > 1 - tol;
+	}
+
+	bool are_triangles_coplanar(
+		const Eigen::Vector3d &t00,
+		const Eigen::Vector3d &t01,
+		const Eigen::Vector3d &t02,
+		const Eigen::Vector3d &t10,
+		const Eigen::Vector3d &t11,
+		const Eigen::Vector3d &t12,
+		const double tol)
+	{
+		const Eigen::Vector3d n0 = (t01 - t00).cross(t02 - t00).normalized();
+		const Eigen::Vector3d n1 = (t11 - t10).cross(t12 - t10).normalized();
+		return abs(n0.dot(n1)) > 1 - tol;
+	}
+
+	// =========================================================================
+	// The following automatically generated using SymPy
+	// =========================================================================
+
+	void triangle_area_2D_gradient(double ax, double ay, double bx, double by, double cx, double cy, double g[6])
+	{
+		const auto t0 = -cy;
+		const auto t1 = -cx;
+		g[0] = (1.0 / 2.0) * by + (1.0 / 2.0) * t0;
+		g[1] = -1.0 / 2.0 * bx - 1.0 / 2.0 * t1;
+		g[2] = -1.0 / 2.0 * ay - 1.0 / 2.0 * t0;
+		g[3] = (1.0 / 2.0) * ax + (1.0 / 2.0) * t1;
+		g[4] = (1.0 / 2.0) * (ay - by);
+		g[5] = (1.0 / 2.0) * (-ax + bx);
+	}
+
+	void triangle_area_2D_hessian(double ax, double ay, double bx, double by, double cx, double cy, double H[36])
+	{
+		H[0] = 0;
+		H[1] = 0;
+		H[2] = 0;
+		H[3] = 1.0 / 2.0;
+		H[4] = 0;
+		H[5] = -1.0 / 2.0;
+		H[6] = 0;
+		H[7] = 0;
+		H[8] = -1.0 / 2.0;
+		H[9] = 0;
+		H[10] = 1.0 / 2.0;
+		H[11] = 0;
+		H[12] = 0;
+		H[13] = -1.0 / 2.0;
+		H[14] = 0;
+		H[15] = 0;
+		H[16] = 0;
+		H[17] = 1.0 / 2.0;
+		H[18] = 1.0 / 2.0;
+		H[19] = 0;
+		H[20] = 0;
+		H[21] = 0;
+		H[22] = -1.0 / 2.0;
+		H[23] = 0;
+		H[24] = 0;
+		H[25] = 1.0 / 2.0;
+		H[26] = 0;
+		H[27] = -1.0 / 2.0;
+		H[28] = 0;
+		H[29] = 0;
+		H[30] = -1.0 / 2.0;
+		H[31] = 0;
+		H[32] = 1.0 / 2.0;
+		H[33] = 0;
+		H[34] = 0;
+		H[35] = 0;
+	}
+
+	void tetrahedron_volume_gradient(double ax, double ay, double az, double bx, double by, double bz, double cx, double cy, double cz, double dx, double dy, double dz, double g[12])
+	{
+		const auto t0 = az - dz;
+		const auto t1 = -cy;
+		const auto t2 = by + t1;
+		const auto t3 = ay - dy;
+		const auto t4 = -cz;
+		const auto t5 = bz + t4;
+		const auto t6 = ay - by;
+		const auto t7 = az + t4;
+		const auto t8 = ay + t1;
+		const auto t9 = az - bz;
+		const auto t10 = t6 * t7 - t8 * t9;
+		const auto t11 = -cx;
+		const auto t12 = bx + t11;
+		const auto t13 = ax - dx;
+		const auto t14 = ax - bx;
+		const auto t15 = ax + t11;
+		const auto t16 = t14 * t7 - t15 * t9;
+		const auto t17 = t14 * t8 - t15 * t6;
+		g[0] = -1.0 / 6.0 * t0 * t2 - 1.0 / 6.0 * t10 + (1.0 / 6.0) * t3 * t5;
+		g[1] = (1.0 / 6.0) * t0 * t12 - 1.0 / 6.0 * t13 * t5 + (1.0 / 6.0) * t16;
+		g[2] = -1.0 / 6.0 * t12 * t3 + (1.0 / 6.0) * t13 * t2 - 1.0 / 6.0 * t17;
+		g[3] = (1.0 / 6.0) * t0 * t8 - 1.0 / 6.0 * t3 * t7;
+		g[4] = -1.0 / 6.0 * t0 * t15 + (1.0 / 6.0) * t13 * t7;
+		g[5] = -1.0 / 6.0 * t13 * t8 + (1.0 / 6.0) * t15 * t3;
+		g[6] = -1.0 / 6.0 * t0 * t6 + (1.0 / 6.0) * t3 * t9;
+		g[7] = (1.0 / 6.0) * t0 * t14 - 1.0 / 6.0 * t13 * t9;
+		g[8] = (1.0 / 6.0) * t13 * t6 - 1.0 / 6.0 * t14 * t3;
+		g[9] = (1.0 / 6.0) * t10;
+		g[10] = -1.0 / 6.0 * t16;
+		g[11] = (1.0 / 6.0) * t17;
+	}
+
+	void tetrahedron_volume_hessian(double ax, double ay, double az, double bx, double by, double bz, double cx, double cy, double cz, double dx, double dy, double dz, double H[144])
+	{
+		const auto t0 = -dz;
+		const auto t1 = cz + t0;
+		const auto t2 = -1.0 / 6.0 * t1;
+		const auto t3 = -dy;
+		const auto t4 = cy + t3;
+		const auto t5 = (1.0 / 6.0) * t4;
+		const auto t6 = bz + t0;
+		const auto t7 = (1.0 / 6.0) * t6;
+		const auto t8 = by + t3;
+		const auto t9 = -1.0 / 6.0 * t8;
+		const auto t10 = -cz;
+		const auto t11 = bz + t10;
+		const auto t12 = -1.0 / 6.0 * t11;
+		const auto t13 = -cy;
+		const auto t14 = by + t13;
+		const auto t15 = (1.0 / 6.0) * t14;
+		const auto t16 = (1.0 / 6.0) * t1;
+		const auto t17 = -dx;
+		const auto t18 = cx + t17;
+		const auto t19 = -1.0 / 6.0 * t18;
+		const auto t20 = -1.0 / 6.0 * t6;
+		const auto t21 = bx + t17;
+		const auto t22 = (1.0 / 6.0) * t21;
+		const auto t23 = (1.0 / 6.0) * t11;
+		const auto t24 = -cx;
+		const auto t25 = bx + t24;
+		const auto t26 = -1.0 / 6.0 * t25;
+		const auto t27 = -1.0 / 6.0 * t4;
+		const auto t28 = (1.0 / 6.0) * t18;
+		const auto t29 = (1.0 / 6.0) * t8;
+		const auto t30 = -1.0 / 6.0 * t21;
+		const auto t31 = -1.0 / 6.0 * t14;
+		const auto t32 = (1.0 / 6.0) * t25;
+		const auto t33 = az + t0;
+		const auto t34 = -1.0 / 6.0 * t33;
+		const auto t35 = ay + t3;
+		const auto t36 = (1.0 / 6.0) * t35;
+		const auto t37 = az + t10;
+		const auto t38 = (1.0 / 6.0) * t37;
+		const auto t39 = ay + t13;
+		const auto t40 = -1.0 / 6.0 * t39;
+		const auto t41 = (1.0 / 6.0) * t33;
+		const auto t42 = ax + t17;
+		const auto t43 = -1.0 / 6.0 * t42;
+		const auto t44 = -1.0 / 6.0 * t37;
+		const auto t45 = ax + t24;
+		const auto t46 = (1.0 / 6.0) * t45;
+		const auto t47 = -1.0 / 6.0 * t35;
+		const auto t48 = (1.0 / 6.0) * t42;
+		const auto t49 = (1.0 / 6.0) * t39;
+		const auto t50 = -1.0 / 6.0 * t45;
+		const auto t51 = az - bz;
+		const auto t52 = -1.0 / 6.0 * t51;
+		const auto t53 = ay - by;
+		const auto t54 = (1.0 / 6.0) * t53;
+		const auto t55 = (1.0 / 6.0) * t51;
+		const auto t56 = ax - bx;
+		const auto t57 = -1.0 / 6.0 * t56;
+		const auto t58 = -1.0 / 6.0 * t53;
+		const auto t59 = (1.0 / 6.0) * t56;
+		H[0] = 0;
+		H[1] = 0;
+		H[2] = 0;
+		H[3] = 0;
+		H[4] = t2;
+		H[5] = t5;
+		H[6] = 0;
+		H[7] = t7;
+		H[8] = t9;
+		H[9] = 0;
+		H[10] = t12;
+		H[11] = t15;
+		H[12] = 0;
+		H[13] = 0;
+		H[14] = 0;
+		H[15] = t16;
+		H[16] = 0;
+		H[17] = t19;
+		H[18] = t20;
+		H[19] = 0;
+		H[20] = t22;
+		H[21] = t23;
+		H[22] = 0;
+		H[23] = t26;
+		H[24] = 0;
+		H[25] = 0;
+		H[26] = 0;
+		H[27] = t27;
+		H[28] = t28;
+		H[29] = 0;
+		H[30] = t29;
+		H[31] = t30;
+		H[32] = 0;
+		H[33] = t31;
+		H[34] = t32;
+		H[35] = 0;
+		H[36] = 0;
+		H[37] = t16;
+		H[38] = t27;
+		H[39] = 0;
+		H[40] = 0;
+		H[41] = 0;
+		H[42] = 0;
+		H[43] = t34;
+		H[44] = t36;
+		H[45] = 0;
+		H[46] = t38;
+		H[47] = t40;
+		H[48] = t2;
+		H[49] = 0;
+		H[50] = t28;
+		H[51] = 0;
+		H[52] = 0;
+		H[53] = 0;
+		H[54] = t41;
+		H[55] = 0;
+		H[56] = t43;
+		H[57] = t44;
+		H[58] = 0;
+		H[59] = t46;
+		H[60] = t5;
+		H[61] = t19;
+		H[62] = 0;
+		H[63] = 0;
+		H[64] = 0;
+		H[65] = 0;
+		H[66] = t47;
+		H[67] = t48;
+		H[68] = 0;
+		H[69] = t49;
+		H[70] = t50;
+		H[71] = 0;
+		H[72] = 0;
+		H[73] = t20;
+		H[74] = t29;
+		H[75] = 0;
+		H[76] = t41;
+		H[77] = t47;
+		H[78] = 0;
+		H[79] = 0;
+		H[80] = 0;
+		H[81] = 0;
+		H[82] = t52;
+		H[83] = t54;
+		H[84] = t7;
+		H[85] = 0;
+		H[86] = t30;
+		H[87] = t34;
+		H[88] = 0;
+		H[89] = t48;
+		H[90] = 0;
+		H[91] = 0;
+		H[92] = 0;
+		H[93] = t55;
+		H[94] = 0;
+		H[95] = t57;
+		H[96] = t9;
+		H[97] = t22;
+		H[98] = 0;
+		H[99] = t36;
+		H[100] = t43;
+		H[101] = 0;
+		H[102] = 0;
+		H[103] = 0;
+		H[104] = 0;
+		H[105] = t58;
+		H[106] = t59;
+		H[107] = 0;
+		H[108] = 0;
+		H[109] = t23;
+		H[110] = t31;
+		H[111] = 0;
+		H[112] = t44;
+		H[113] = t49;
+		H[114] = 0;
+		H[115] = t55;
+		H[116] = t58;
+		H[117] = 0;
+		H[118] = 0;
+		H[119] = 0;
+		H[120] = t12;
+		H[121] = 0;
+		H[122] = t32;
+		H[123] = t38;
+		H[124] = 0;
+		H[125] = t50;
+		H[126] = t52;
+		H[127] = 0;
+		H[128] = t59;
+		H[129] = 0;
+		H[130] = 0;
+		H[131] = 0;
+		H[132] = t15;
+		H[133] = t26;
+		H[134] = 0;
+		H[135] = t40;
+		H[136] = t46;
+		H[137] = 0;
+		H[138] = t54;
+		H[139] = t57;
+		H[140] = 0;
+		H[141] = 0;
+		H[142] = 0;
+		H[143] = 0;
+	}
+} // namespace polyfem::utils

--- a/src/polyfem/utils/GeometryUtils.hpp
+++ b/src/polyfem/utils/GeometryUtils.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace polyfem::utils
+{
+	/// @brief Compute the signed area of a 2D triangle defined by three points.
+	/// @param a First point of the triangle.
+	/// @param b Second point of the triangle.
+	/// @param c Third point of the triangle.
+	/// @return The signed area of the triangle.
+	double triangle_area_2D(
+		const Eigen::Vector2d &a,
+		const Eigen::Vector2d &b,
+		const Eigen::Vector2d &c);
+
+	/// @brief Compute the area of a 3D triangle defined by three points.
+	/// @param a First point of the triangle.
+	/// @param b Second point of the triangle.
+	/// @param c Third point of the triangle.
+	/// @return The signed area of the triangle.
+	double triangle_area_3D(
+		const Eigen::Vector3d &a,
+		const Eigen::Vector3d &b,
+		const Eigen::Vector3d &c);
+
+	/// @brief Compute the signed area of a triangle defined by three points.
+	/// @param V The vertices of the triangle as rows of a matrix.
+	/// @return The signed area of the triangle.
+	double triangle_area(const Eigen::MatrixXd V);
+
+	/// @brief Compute the signed volume of a tetrahedron defined by four points.
+	/// @param a First point of the tetrahedron.
+	/// @param b Second point of the tetrahedron.
+	/// @param c Third point of the tetrahedron.
+	/// @param d Fourth point of the tetrahedron.
+	/// @return The signed volume of the tetrahedron.
+	double tetrahedron_volume(
+		const Eigen::Vector3d &a,
+		const Eigen::Vector3d &b,
+		const Eigen::Vector3d &c,
+		const Eigen::Vector3d &d);
+
+	/// @brief Compute the signed volume of a tetrahedron defined by four points.
+	/// @param V The vertices of the terahedron as rows of a matrix.
+	/// @return The signed volume of the tetrahedron.
+	double tetrahedron_volume(const Eigen::MatrixXd V);
+
+	/// @brief Compute the gradient of the signed area of a 2D triangle defined by three points.
+	/// @param ax First point's x coordinate.
+	/// @param ay First point's y coordinate.
+	/// @param bx Second point's x coordinate.
+	/// @param by Second point's y coordinate.
+	/// @param cx Third point's x coordinate.
+	/// @param cy Third point's y coordinate.
+	/// @param g Output gradient with respect to the three points.
+	void triangle_area_2D_gradient(double ax, double ay, double bx, double by, double cx, double cy, double g[6]);
+
+	/// @brief Compute the Hessian of the signed area of a 2D triangle defined by three points.
+	/// @param ax First point's x coordinate.
+	/// @param ay First point's y coordinate.
+	/// @param bx Second point's x coordinate.
+	/// @param by Second point's y coordinate.
+	/// @param cx Third point's x coordinate.
+	/// @param cy Third point's y coordinate.
+	/// @param g Output flattened Hessian with respect to the three points.
+	void triangle_area_2D_hessian(double ax, double ay, double bx, double by, double cx, double cy, double H[36]);
+
+	/// @brief Compute the gradient of the signed volume of a tetrahedron defined by four points.
+	/// @param ax First point's x coordinate.
+	/// @param ay First point's y coordinate.
+	/// @param ay First point's z coordinate.
+	/// @param bx Second point's x coordinate.
+	/// @param by Second point's y coordinate.
+	/// @param by Second point's z coordinate.
+	/// @param cx Third point's x coordinate.
+	/// @param cy Third point's y coordinate.
+	/// @param cy Third point's z coordinate.
+	/// @param dx Fourth point's x coordinate.
+	/// @param dy Fourth point's y coordinate.
+	/// @param dy Fourth point's z coordinate.
+	/// @param g Output gradient with respect to the four points.
+	void tetrahedron_volume_gradient(double ax, double ay, double az, double bx, double by, double bz, double cx, double cy, double cz, double dx, double dy, double dz, double g[12]);
+
+	/// @brief Compute the gradient of the signed area of a 2D triangle defined by three points.
+	/// @param ax First point's x coordinate.
+	/// @param ay First point's y coordinate.
+	/// @param ay First point's z coordinate.
+	/// @param bx Second point's x coordinate.
+	/// @param by Second point's y coordinate.
+	/// @param by Second point's z coordinate.
+	/// @param cx Third point's x coordinate.
+	/// @param cy Third point's y coordinate.
+	/// @param cy Third point's z coordinate.
+	/// @param dx Fourth point's x coordinate.
+	/// @param dy Fourth point's y coordinate.
+	/// @param dy Fourth point's z coordinate.
+	/// @param g Output flattened Hessian with respect to the four points.
+	void tetrahedron_volume_hessian(double ax, double ay, double az, double bx, double by, double bz, double cx, double cy, double cz, double dx, double dy, double dz, double H[144]);
+
+	/// @brief Reorder the vertices of a triangle so they are in clockwise order.
+	/// @param triangle The vertices of the triangle as rows of a matrix.
+	/// @return The vertices of the triangle in clockwise order as rows of a matrix.
+	Eigen::MatrixXd triangle_to_clockwise_order(const Eigen::MatrixXd &triangle);
+
+	/// @brief Convert a convex polygon to a list of triangles fanned around the first vertex.
+	/// @param convex_polygon The vertices of the convex polygon as rows of a matrix.
+	/// @return The list of triangles as matrices of rows.
+	std::vector<Eigen::MatrixXd> triangle_fan(const Eigen::MatrixXd &convex_polygon);
+
+	/// @brief Compute barycentric coordinates for point p with respect to a simplex.
+	/// @param p Query point.
+	/// @param V Verties of the simplex as rows of a matrix.
+	/// @return The barycentric coordinates for point p with respect to the simplex.
+	Eigen::VectorXd barycentric_coordinates(
+		const Eigen::VectorXd &p,
+		const Eigen::MatrixXd &V);
+
+	/// @brief Determine if a 2D triangle intersects a 2D disk.
+	/// @param t0 Triangle first vertex.
+	/// @param t1 Triangle second vertex.
+	/// @param t2 Triangle third vertex.
+	/// @param center Center of the disk.
+	/// @param radius Radius of the disk.
+	/// @return True if the triangle intersects the disk, false otherwise.
+	bool triangle_intersects_disk(
+		const Eigen::Vector2d &t0,
+		const Eigen::Vector2d &t1,
+		const Eigen::Vector2d &t2,
+		const Eigen::Vector2d &center,
+		const double radius);
+
+	/// @brief Determine if a 3D tetrahedron intersects a 3D ball.
+	/// @param t0 Tetrahedron first vertex.
+	/// @param t1 Tetrahedron second vertex.
+	/// @param t2 Tetrahedron third vertex.
+	/// @param t3 Tetrahedron fourth vertex.
+	/// @param center Center of the ball.
+	/// @param radius Radius of the ball.
+	/// @return True if the tetrahedron intersects the ball, false otherwise.
+	bool tetrahedron_intersects_ball(
+		const Eigen::Vector3d &t0,
+		const Eigen::Vector3d &t1,
+		const Eigen::Vector3d &t2,
+		const Eigen::Vector3d &t3,
+		const Eigen::Vector3d &center,
+		const double radius);
+
+	/// @brief Determine if two edges are collinear.
+	/// @param ea0 First vertex of the first edge.
+	/// @param ea1 Second vertex of the first edge.
+	/// @param eb0 First vertex of the second edge.
+	/// @param eb1 Second vertex of the second edge.
+	/// @param tol Tolerance for collinearity.
+	/// @return True if the edges are collinear, false otherwise.
+	bool are_edges_collinear(
+		const Eigen::VectorXd &ea0,
+		const Eigen::VectorXd &ea1,
+		const Eigen::VectorXd &eb0,
+		const Eigen::VectorXd &eb1,
+		const double tol = 1e-10);
+
+	/// @brief Determine if two triangles are coplanar.
+	/// @param t00 First vertex of the first triangle.
+	/// @param t01 Second vertex of the first triangle.
+	/// @param t02 Third vertex of the first triangle.
+	/// @param t10 First vertex of the second triangle.
+	/// @param t11 Second vertex of the second triangle.
+	/// @param t12 Third vertex of the second triangle.
+	/// @param tol Tolerance for coplanarity.
+	/// @return True if the triangles are coplanar, false otherwise.
+	bool are_triangles_coplanar(
+		const Eigen::Vector3d &t00,
+		const Eigen::Vector3d &t01,
+		const Eigen::Vector3d &t02,
+		const Eigen::Vector3d &t10,
+		const Eigen::Vector3d &t11,
+		const Eigen::Vector3d &t12,
+		const double tol = 1e-10);
+} // namespace polyfem::utils

--- a/src/polyfem/utils/HashUtils.hpp
+++ b/src/polyfem/utils/HashUtils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef> // size_t
+#include <array>
 #include <vector>
 
 namespace polyfem::utils
@@ -27,6 +28,33 @@ namespace polyfem::utils
 		h ^= (h >> 32);
 		return h;
 	}
+
+	/// @brief Hash function for an array where the order does not matter.
+	template <typename T, int N>
+	struct HashUnorderedArray
+	{
+		size_t operator()(std::array<T, N> v) const noexcept
+		{
+			std::sort(v.begin(), v.end()); // Sort the array to make the order irrelevant.
+			std::hash<T> hasher;
+			size_t hash = 0;
+			for (int i : v)
+				hash ^= hasher(i) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+			return hash;
+		}
+	};
+
+	template <typename T, int N>
+	struct EqualUnorderedArray
+	{
+		bool operator()(std::array<T, N> v1, std::array<T, N> v2) const noexcept
+		{
+			// Sort the array to make the order irrelevant.
+			std::sort(v1.begin(), v1.end());
+			std::sort(v2.begin(), v2.end());
+			return v1 == v2;
+		}
+	};
 
 	struct HashVector
 	{

--- a/src/polyfem/utils/MatrixUtils.hpp
+++ b/src/polyfem/utils/MatrixUtils.hpp
@@ -115,5 +115,59 @@ namespace polyfem
 			const std::vector<int> &removed_vars,
 			const StiffnessMatrix &full,
 			StiffnessMatrix &reduced);
+
+		/// @brief Reorder row blocks in a matrix.
+		/// @param in Input matrix.
+		/// @param in_to_out Mapping from input blocks to output blocks.
+		/// @param out_blocks Number of blocks in the output matrix.
+		/// @param block_size Size of each block.
+		/// @return Reordered matrix.
+		Eigen::MatrixXd reorder_matrix(
+			const Eigen::MatrixXd &in,
+			const Eigen::VectorXi &in_to_out,
+			int out_blocks = -1,
+			const int block_size = 1);
+
+		/// @brief Undo the reordering of row blocks in a matrix.
+		/// @param out Reordered matrix.
+		/// @param in_to_out Mapping from input blocks to output blocks.
+		/// @param in_blocks Number of blocks in the input matrix.
+		/// @param block_size Size of each block.
+		/// @return Unreordered matrix.
+		Eigen::MatrixXd unreorder_matrix(
+			const Eigen::MatrixXd &out,
+			const Eigen::VectorXi &in_to_out,
+			int in_blocks = -1,
+			const int block_size = 1);
+
+		/// @brief Map the entrys of an index matrix to new indices.
+		/// @param in Input index matrix.
+		/// @param index_mapping Mapping from old to new indices.
+		/// @return Mapped index matrix.
+		Eigen::MatrixXi map_index_matrix(
+			const Eigen::MatrixXi &in,
+			const Eigen::VectorXi &index_mapping);
+
+		template <typename DstMat, typename SrcMat>
+		void append_rows(DstMat &dst, const SrcMat &src)
+		{
+			if (src.rows() == 0)
+				return;
+			if (dst.cols() == 0)
+				dst.resize(dst.rows(), src.cols());
+			assert(dst.cols() == src.cols());
+			dst.conservativeResize(dst.rows() + src.rows(), dst.cols());
+			dst.bottomRows(src.rows()) = src;
+		}
+
+		template <typename DstMat>
+		void append_zero_rows(DstMat &dst, const size_t n_zero_rows)
+		{
+			assert(dst.cols() > 0);
+			if (n_zero_rows == 0)
+				return;
+			dst.conservativeResize(dst.rows() + n_zero_rows, dst.cols());
+			dst.bottomRows(n_zero_rows).setZero();
+		}
 	} // namespace utils
 } // namespace polyfem

--- a/src/polyfem/utils/Timer.hpp
+++ b/src/polyfem/utils/Timer.hpp
@@ -47,12 +47,16 @@ namespace polyfem
 
 			inline void start()
 			{
+				is_running = true;
 				m_timer.start();
 			}
 
 			inline void stop()
 			{
+				if (!is_running)
+					return;
 				m_timer.stop();
+				is_running = false;
 				log_msg();
 				if (m_total_time)
 				{
@@ -85,6 +89,7 @@ namespace polyfem
 			std::string m_name;
 			igl::Timer m_timer;
 			double *m_total_time;
+			bool is_running = false;
 		};
 	} // namespace utils
 } // namespace polyfem

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(test_sources
 	test_bases.cpp
 	test_matrix.cpp
   test_cmesh.cpp
+  test_geometry_utils.cpp
   test_ncmesh.cpp
 	test_normal.cpp
 	test_problem.cpp

--- a/tests/test_geometry_utils.cpp
+++ b/tests/test_geometry_utils.cpp
@@ -1,0 +1,42 @@
+#include <catch2/catch.hpp>
+
+#include <polyfem/utils/GeometryUtils.hpp>
+
+TEST_CASE("Triangle area", "[geometry]")
+{
+	using namespace polyfem::utils;
+
+	Eigen::Matrix3d V;
+	V << 0, 0, 0,
+		1, 0, 0,
+		0, 1, 0;
+
+	CHECK(triangle_area(V.leftCols<2>()) == Approx(0.5));
+	CHECK(triangle_area(V) == Approx(0.5));
+
+	Eigen::Matrix3d V_flipped = V;
+	V_flipped.row(1) = V.row(2);
+	V_flipped.row(2) = V.row(1);
+
+	CHECK(triangle_area(V_flipped.leftCols<2>()) == Approx(-0.5));
+	CHECK(triangle_area(V_flipped) == Approx(0.5));
+}
+
+TEST_CASE("Tetrahedron volume", "[geometry]")
+{
+	using namespace polyfem::utils;
+
+	Eigen::Matrix<double, 4, 3> V;
+	V << 0, 0, 0,
+		1, 0, 0,
+		0, 1, 0,
+		0, 0, 1;
+
+	CHECK(tetrahedron_volume(V) == Approx(1 / 6.));
+
+	Eigen::Matrix<double, 4, 3> V_flipped = V;
+	V_flipped.row(2) = V.row(3);
+	V_flipped.row(3) = V.row(2);
+
+	CHECK(tetrahedron_volume(V_flipped) == Approx(-1 / 6.));
+}


### PR DESCRIPTION
Major changes:
* Removed `use_grad_norm` from the NLSolver in favor of using `xDelta` convergence criteria. This allows us to use both convergence criteria and is more understandable for users. 
    * :warning: This breaks old JSON that used the `"solver/nonlinear/use_grad_norm"` key. To update users should set `"solver/nonlinear/x_delta"` to a positive value for the tolerance.
* created a `SolveData.hpp/.cpp` to  store all the SolveData class methods
    * moved initializing forms in to SolveData

Minor changes:
* bump libigl to 2.4.0
* update PolySolver
* optionally save a "restart" JSON to make restarting easier
* optionally use the convergent IPC formulation
* save `u,v,a` at every time-step
* moved `State::set_materials` into `AssemblerUtils`
* add `GeometryUtils`
* move polygon clipping stuff into `ClipperUtils`