### PR TITLE
Different Coefficient of Friction per Object Pairing

### DIFF
--- a/input-spec.json
+++ b/input-spec.json
@@ -1421,6 +1421,44 @@
         "doc": "Coefficient of friction (global)"
     },
     {
+        "pointer": "/contact/friction_coefficient",
+        "type": "list",
+        "doc": "Coefficient of friction (pairwise)"
+    },
+    {
+        "pointer": "/contact/friction_coefficient/*",
+        "type": "object",
+        "required": [
+            "ids",
+            "value"
+        ],
+        "doc": "Coefficient of friction (pairwise)"
+    },
+    {
+        "pointer": "/contact/friction_coefficient/*/ids",
+        "type": "list",
+        "max": 2,
+        "doc": "Surface IDs for coeffient of friction"
+    },
+    {
+        "pointer": "/contact/friction_coefficient/*/value",
+        "type": "float",
+        "doc": "Coefficient of friction"
+    },
+    {
+        "pointer": "/contact/friction_coefficient/*/ids/*",
+        "type": "int",
+        "doc": "Surface ID for coeffient of friction"
+    },
+    {
+        "pointer": "/contact/friction_coefficient/*/ids/*",
+        "type": "string",
+        "options": [
+            "all"
+        ],
+        "doc": "Surface ID for coeffient of friction"
+    },
+    {
         "pointer": "/contact/use_convergent_formulation",
         "default": false,
         "type": "bool",


### PR DESCRIPTION
Implement a different coefficient of friction (COF) per object pairing. This does not use a blending model but instead specifies the COF for each pair of surface IDs (quadratic number).

This is a PR to address #198.

NOTE: this is currently a draft PR for discussion