### PR TITLE
Update IPC Toolkit

### DIFF
--- a/cmake/recipes/ipc_toolkit.cmake
+++ b/cmake/recipes/ipc_toolkit.cmake
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
     ipc_toolkit
     GIT_REPOSITORY https://github.com/ipc-sim/ipc-toolkit.git
-    GIT_TAG c1ba93d475ceb8e906e4cf44d8cf992b67235788
+    GIT_TAG c844956c748d6a086613f22361c5304ecaa16303
     GIT_SHALLOW FALSE
 )
 FetchContent_MakeAvailable(ipc_toolkit)

--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -27,7 +27,7 @@ else()
         PREFIX ${FETCHCONTENT_BASE_DIR}/polyfem-test-data
         SOURCE_DIR ${POLYFEM_DATA_DIR}
         GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-        GIT_TAG 7100824
+        GIT_TAG 6a2572d3e1ad60b6c8cb124f1fde6212219e35a2
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -27,7 +27,7 @@ else()
         PREFIX ${FETCHCONTENT_BASE_DIR}/polyfem-test-data
         SOURCE_DIR ${POLYFEM_DATA_DIR}
         GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-        GIT_TAG 6a2572d3e1ad60b6c8cb124f1fde6212219e35a2
+        GIT_TAG 87f0ecab929b5f3a0ae827980014318cee9a0f9c
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/src/polyfem/State.cpp
+++ b/src/polyfem/State.cpp
@@ -879,8 +879,8 @@ namespace polyfem
 			double min_boundary_edge_length = std::numeric_limits<double>::max();
 			for (const auto &edge : collision_mesh.edges().rowwise())
 			{
-				const VectorNd v0 = collision_mesh.vertices_at_rest().row(edge(0));
-				const VectorNd v1 = collision_mesh.vertices_at_rest().row(edge(1));
+				const VectorNd v0 = collision_mesh.rest_positions().row(edge(0));
+				const VectorNd v1 = collision_mesh.rest_positions().row(edge(1));
 				min_boundary_edge_length = std::min(min_boundary_edge_length, (v1 - v0).norm());
 			}
 

--- a/src/polyfem/mesh/Obstacle.cpp
+++ b/src/polyfem/mesh/Obstacle.cpp
@@ -267,19 +267,21 @@ namespace polyfem
 			{
 				assert(dim_ == 3);
 
-				Eigen::Vector3d cross_x = ipc::cross(Eigen::Vector3d::UnitX(), normal());
-				Eigen::Vector3d cross_y = ipc::cross(Eigen::Vector3d::UnitY(), normal());
+				const Eigen::Vector3d normal = this->normal();
+
+				const Eigen::Vector3d cross_x = Eigen::Vector3d::UnitX().cross(normal);
+				const Eigen::Vector3d cross_y = Eigen::Vector3d::UnitY().cross(normal);
 
 				Eigen::Vector3d tangent_x, tangent_y;
 				if (cross_x.squaredNorm() > cross_y.squaredNorm())
 				{
 					tangent_x = cross_x.normalized();
-					tangent_y = ipc::cross(normal(), cross_x).normalized();
+					tangent_y = normal.cross(cross_x).normalized();
 				}
 				else
 				{
 					tangent_x = cross_y.normalized();
-					tangent_y = ipc::cross(normal(), cross_y).normalized();
+					tangent_y = normal.cross(cross_y).normalized();
 				}
 
 				vis_v_.resize((size_x + 1) * (size_y + 1), 3);

--- a/src/polyfem/solver/SolveData.cpp
+++ b/src/polyfem/solver/SolveData.cpp
@@ -168,8 +168,8 @@ namespace polyfem::solver
 			if (friction_coefficient != 0)
 			{
 				friction_form = std::make_shared<FrictionForm>(
-					collision_mesh, epsv, friction_coefficient, dhat, broad_phase,
-					is_time_dependent ? dt : 1.0, *contact_form, friction_iterations);
+					collision_mesh, time_integrator, epsv, friction_coefficient, dhat, broad_phase,
+					*contact_form, friction_iterations);
 				forms.push_back(friction_form);
 			}
 		}

--- a/src/polyfem/solver/forms/ContactForm.hpp
+++ b/src/polyfem/solver/forms/ContactForm.hpp
@@ -5,7 +5,7 @@
 #include <polyfem/Common.hpp>
 #include <polyfem/utils/Types.hpp>
 
-#include <ipc/ipc.hpp>
+#include <ipc/collisions/collision_constraints.hpp>
 #include <ipc/collision_mesh.hpp>
 #include <ipc/broad_phase/broad_phase.hpp>
 
@@ -125,7 +125,10 @@ namespace polyfem::solver
 		void update_barrier_stiffness(const Eigen::VectorXd &x, const Eigen::MatrixXd &grad_energy);
 
 		inline bool use_adaptive_barrier_stiffness() const { return use_adaptive_barrier_stiffness_; }
-		inline bool use_convergent_formulation() const { return constraint_set_.use_convergent_formulation; }
+		inline bool use_convergent_formulation() const { return constraint_set_.use_convergent_formulation(); }
+
+		/// @brief Compute the displaced positions of the surface nodes
+		Eigen::MatrixXd compute_displaced_surface(const Eigen::VectorXd &x) const;
 
 		bool save_ccd_debug_meshes = false; ///< If true, output debug files
 
@@ -133,6 +136,9 @@ namespace polyfem::solver
 		const ipc::CollisionMesh &collision_mesh_;
 
 		const double dhat_; ///< Barrier activation distance
+
+		// TODO: Make this a parameter
+		const double dmin_ = 0; ///< Minimum distance between elements
 
 		const double avg_mass_;
 
@@ -147,12 +153,9 @@ namespace polyfem::solver
 
 		double prev_distance_; ///< Previous minimum distance between all elements
 
-		bool use_cached_candidates_ = false; ///< If true, use the cached candidate set for the current solution
-		ipc::Constraints constraint_set_;    ///< Cached constraint set for the current solution
-		ipc::Candidates candidates_;         ///< Cached candidate set for the current solution
-
-		/// @brief Compute the displaced positions of the surface nodes
-		Eigen::MatrixXd compute_displaced_surface(const Eigen::VectorXd &x) const;
+		bool use_cached_candidates_ = false;       ///< If true, use the cached candidate set for the current solution
+		ipc::CollisionConstraints constraint_set_; ///< Cached constraint set for the current solution
+		ipc::Candidates candidates_;               ///< Cached candidate set for the current solution
 
 		/// @brief Update the cached candidate set for the current solution
 		/// @param displaced_surface Vertex positions displaced by the current solution

--- a/src/polyfem/solver/forms/FrictionForm.cpp
+++ b/src/polyfem/solver/forms/FrictionForm.cpp
@@ -8,17 +8,17 @@ namespace polyfem::solver
 {
 	FrictionForm::FrictionForm(
 		const ipc::CollisionMesh &collision_mesh,
+		const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator,
 		const double epsv,
 		const double mu,
 		const double dhat,
 		const ipc::BroadPhaseMethod broad_phase_method,
-		const double dt,
 		const ContactForm &contact_form,
 		const int n_lagging_iters)
 		: collision_mesh_(collision_mesh),
+		  time_integrator_(time_integrator),
 		  epsv_(epsv),
 		  mu_(mu),
-		  dt_(dt),
 		  dhat_(dhat),
 		  broad_phase_method_(broad_phase_method),
 		  contact_form_(contact_form),
@@ -29,7 +29,19 @@ namespace polyfem::solver
 
 	Eigen::MatrixXd FrictionForm::compute_displaced_surface(const Eigen::VectorXd &x) const
 	{
-		return collision_mesh_.displace_vertices(utils::unflatten(x, collision_mesh_.dim()));
+		return contact_form_.compute_displaced_surface(x);
+	}
+
+	Eigen::MatrixXd FrictionForm::compute_surface_velocities(const Eigen::VectorXd &x) const
+	{
+		// In the case of a static problem, the velocity is the displacement
+		const Eigen::VectorXd v = time_integrator_ != nullptr ? time_integrator_->compute_velocity(x) : x;
+		return collision_mesh_.map_displacements(utils::unflatten(v, collision_mesh_.dim()));
+	}
+
+	double FrictionForm::dv_dx() const
+	{
+		return time_integrator_ != nullptr ? time_integrator_->dv_dx() : 1;
 	}
 
 	double FrictionForm::value_unweighted(const Eigen::VectorXd &x) const
@@ -37,18 +49,15 @@ namespace polyfem::solver
 		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
 		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
 
-		return ipc::compute_friction_potential(
-			collision_mesh_, displaced_surface_prev_, compute_displaced_surface(x),
-			friction_constraint_set_, epsv_ * dt_);
+		return friction_constraint_set_.compute_potential(collision_mesh_, compute_surface_velocities(x), epsv_) / dv_dx();
 	}
 	void FrictionForm::first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
 		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
 
-		const Eigen::VectorXd grad_friction = ipc::compute_friction_potential_gradient(
-			collision_mesh_, displaced_surface_prev_, compute_displaced_surface(x),
-			friction_constraint_set_, epsv_ * dt_);
+		const Eigen::VectorXd grad_friction = friction_constraint_set_.compute_potential_gradient(
+			collision_mesh_, compute_surface_velocities(x), epsv_);
 		gradv = collision_mesh_.to_full_dof(grad_friction);
 	}
 
@@ -59,32 +68,24 @@ namespace polyfem::solver
 		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
 		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
 
-		hessian = ipc::compute_friction_potential_hessian(
-			collision_mesh_, displaced_surface_prev_, compute_displaced_surface(x),
-			friction_constraint_set_, epsv_ * dt_, project_to_psd_);
+		hessian = dv_dx() * friction_constraint_set_.compute_potential_hessian( //
+					  collision_mesh_, compute_surface_velocities(x), epsv_, project_to_psd_);
 
 		hessian = collision_mesh_.to_full_dof(hessian);
-	}
-
-	// TODO: handle lagging with more than one step
-	void FrictionForm::init_lagging(const Eigen::VectorXd &x)
-	{
-		displaced_surface_prev_ = compute_displaced_surface(x);
-		update_lagging(x, 0);
 	}
 
 	void FrictionForm::update_lagging(const Eigen::VectorXd &x, const int iter_num)
 	{
 		const Eigen::MatrixXd displaced_surface = compute_displaced_surface(x);
 
-		ipc::Constraints constraint_set;
-		constraint_set.use_convergent_formulation = contact_form_.use_convergent_formulation();
+		ipc::CollisionConstraints constraint_set;
+		constraint_set.set_use_convergent_formulation(contact_form_.use_convergent_formulation());
 		constraint_set.build(
 			collision_mesh_, displaced_surface, dhat_,
 			/*dmin=*/0, broad_phase_method_);
 
-		ipc::construct_friction_constraint_set(
+		friction_constraint_set_.build(
 			collision_mesh_, displaced_surface, constraint_set,
-			dhat_, contact_form_.barrier_stiffness(), mu_, friction_constraint_set_);
+			dhat_, contact_form_.barrier_stiffness(), mu_);
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/FrictionForm.cpp
+++ b/src/polyfem/solver/forms/FrictionForm.cpp
@@ -46,16 +46,10 @@ namespace polyfem::solver
 
 	double FrictionForm::value_unweighted(const Eigen::VectorXd &x) const
 	{
-		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
-		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
-
 		return friction_constraint_set_.compute_potential(collision_mesh_, compute_surface_velocities(x), epsv_) / dv_dx();
 	}
 	void FrictionForm::first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
-		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
-		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
-
 		const Eigen::VectorXd grad_friction = friction_constraint_set_.compute_potential_gradient(
 			collision_mesh_, compute_surface_velocities(x), epsv_);
 		gradv = collision_mesh_.to_full_dof(grad_friction);
@@ -64,9 +58,6 @@ namespace polyfem::solver
 	void FrictionForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 	{
 		POLYFEM_SCOPED_TIMER("friction hessian");
-
-		assert(displaced_surface_prev_.rows() == collision_mesh_.num_vertices());
-		assert(displaced_surface_prev_.cols() == collision_mesh_.dim());
 
 		hessian = dv_dx() * friction_constraint_set_.compute_potential_hessian( //
 					  collision_mesh_, compute_surface_velocities(x), epsv_, project_to_psd_);

--- a/src/polyfem/solver/forms/FrictionForm.hpp
+++ b/src/polyfem/solver/forms/FrictionForm.hpp
@@ -2,11 +2,12 @@
 
 #include "Form.hpp"
 
+#include <polyfem/time_integrator/ImplicitTimeIntegrator.hpp>
 #include <polyfem/utils/Types.hpp>
 
 #include <ipc/ipc.hpp>
 #include <ipc/collision_mesh.hpp>
-#include <ipc/friction/friction_constraint.hpp>
+#include <ipc/friction/friction_constraints.hpp>
 
 namespace polyfem::solver
 {
@@ -18,20 +19,20 @@ namespace polyfem::solver
 	public:
 		/// @brief Construct a new Friction Form object
 		/// @param collision_mesh Reference to the collision mesh
+		/// @param time_integrator Pointer to the time integrator
 		/// @param epsv Smoothing factor between static and dynamic friction
 		/// @param mu Global coefficient of friction
 		/// @param dhat Barrier activation distance
 		/// @param broad_phase_method Broad-phase method used for distance computation and collision detection
-		/// @param dt Time step size
 		/// @param contact_form Pointer to contact form; necessary to have the barrier stiffnes, maybe clean me
 		/// @param n_lagging_iters Number of lagging iterations
 		FrictionForm(
 			const ipc::CollisionMesh &collision_mesh,
+			const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator,
 			const double epsv,
 			const double mu,
 			const double dhat,
 			const ipc::BroadPhaseMethod broad_phase_method,
-			const double dt,
 			const ContactForm &contact_form,
 			const int n_lagging_iters);
 
@@ -54,7 +55,7 @@ namespace polyfem::solver
 	public:
 		/// @brief Initialize lagged fields
 		/// @param x Current solution
-		void init_lagging(const Eigen::VectorXd &x) override;
+		void init_lagging(const Eigen::VectorXd &x) override { update_lagging(x, 0); }
 
 		/// @brief Update lagged fields
 		/// @param x Current solution
@@ -71,23 +72,27 @@ namespace polyfem::solver
 		/// @return True if the form requires lagging
 		bool uses_lagging() const override { return true; }
 
-		const Eigen::MatrixXd &displaced_surface_prev() const { return displaced_surface_prev_; }
+		/// @brief Compute the displaced positions of the surface nodes
+		Eigen::MatrixXd compute_displaced_surface(const Eigen::VectorXd &x) const;
+		/// @brief Compute the surface velocities
+		Eigen::MatrixXd compute_surface_velocities(const Eigen::VectorXd &x) const;
+		/// @brief Compute the derivative of the velocities wrt x
+		double dv_dx() const;
 
 	private:
+		/// Reference to the collision mesh
 		const ipc::CollisionMesh &collision_mesh_;
+
+		/// Pointer to the time integrator
+		const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator_;
 
 		const double epsv_;                              ///< Smoothing factor between static and dynamic friction
 		const double mu_;                                ///< Global coefficient of friction
-		const double dt_;                                ///< Time step size
 		const double dhat_;                              ///< Barrier activation distance
 		const ipc::BroadPhaseMethod broad_phase_method_; ///< Broad-phase method used for distance computation and collision detection
 		const int n_lagging_iters_;                      ///< Number of lagging iterations
 
 		ipc::FrictionConstraints friction_constraint_set_; ///< Lagged friction constraint set
-		Eigen::MatrixXd displaced_surface_prev_;           ///< Displaced vertices at the start of the time-step.
-
-		/// @brief Compute the displaced positions of the surface nodes
-		Eigen::MatrixXd compute_displaced_surface(const Eigen::VectorXd &x) const;
 
 		const ContactForm &contact_form_; ///< necessary to have the barrier stiffnes, maybe clean me
 	};

--- a/src/polyfem/time_integrator/ImplicitTimeIntegrator.hpp
+++ b/src/polyfem/time_integrator/ImplicitTimeIntegrator.hpp
@@ -67,7 +67,7 @@ namespace polyfem::time_integrator
 		/// @brief Access the time step size.
 		const double &dt() const { return dt_; }
 
-		/// @brief Save the values of \$x\$, \f$v\f$, and \f$a\f$.
+		/// @brief Save the values of \f$x\f$, \f$v\f$, and \f$a\f$.
 		/// @param x_path path for the output file containing \f$x\f$, if the extension is `.txt`
 		///               then it will write an ASCII file else if the extension is `.bin` it will
 		///               write a binary file.

--- a/tests/test_form_derivatives.cpp
+++ b/tests/test_form_derivatives.cpp
@@ -227,7 +227,7 @@ TEST_CASE("friction form derivatives", "[form][form_derivatives][friction_form]"
 		ccd_tolerance, ccd_max_iterations);
 
 	FrictionForm form(
-		state_ptr->collision_mesh, epsv, mu, dhat, broad_phase_method, dt,
+		state_ptr->collision_mesh, nullptr, epsv, mu, dhat, broad_phase_method,
 		contact_form, /*n_lagging_iters=*/-1);
 
 	test_form(form, *state_ptr);


### PR DESCRIPTION
This is mostly an update to match the new IPC Toolkit API. The largest change is that friction no longer directly depends on the current and previous displacement but instead depends on the current velocity. This means the friction form needs the time integrator to compute the velocity given the current displacement. For static simulation (where the time integrator is a `nullptr`), I use the displacement directly.