### PR TITLE
Add missing acceleration scaling to contact and friction forms

### DIFF
--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -27,7 +27,7 @@ else()
         PREFIX ${FETCHCONTENT_BASE_DIR}/polyfem-test-data
         SOURCE_DIR ${POLYFEM_DATA_DIR}
         GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-        GIT_TAG 62b3e2f
+        GIT_TAG c88e38b05d22e96ce9466bf7f76e7d5f5eede42a
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/cmake/recipes/polyfem_data.cmake
+++ b/cmake/recipes/polyfem_data.cmake
@@ -27,7 +27,7 @@ else()
         PREFIX ${FETCHCONTENT_BASE_DIR}/polyfem-test-data
         SOURCE_DIR ${POLYFEM_DATA_DIR}
         GIT_REPOSITORY https://github.com/polyfem/polyfem-data
-        GIT_TAG c88e38b05d22e96ce9466bf7f76e7d5f5eede42a
+        GIT_TAG 6351dc4c70b4dd543c9780893830197ac17a44ac
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""

--- a/src/polyfem/io/OutData.cpp
+++ b/src/polyfem/io/OutData.cpp
@@ -1776,7 +1776,7 @@ namespace polyfem::io
 				collision_mesh, displaced_surface, dhat,
 				/*dmin=*/0, state.args["solver"]["contact"]["CCD"]["broad_phase"]);
 
-			const double barrier_stiffness = contact_form != nullptr ? contact_form->barrier_stiffness() : 1;
+			const double barrier_stiffness = contact_form != nullptr ? contact_form->weight() : 1;
 
 			if (opts.contact_forces)
 			{

--- a/src/polyfem/solver/SolveData.cpp
+++ b/src/polyfem/solver/SolveData.cpp
@@ -164,14 +164,13 @@ namespace polyfem::solver
 
 			if (use_adaptive_barrier_stiffness)
 			{
-				contact_form->set_weight(1);
+				contact_form->set_barrier_stiffness(1);
 				// logger().debug("Using adaptive barrier stiffness");
 			}
 			else
 			{
-				assert(barrier_stiffness.is_number());
 				assert(barrier_stiffness.get<double>() > 0);
-				contact_form->set_weight(barrier_stiffness);
+				contact_form->set_barrier_stiffness(barrier_stiffness);
 				// logger().debug("Using fixed barrier stiffness of {}", contact_form->barrier_stiffness());
 			}
 
@@ -216,52 +215,37 @@ namespace polyfem::solver
 
 	void SolveData::update_barrier_stiffness(const Eigen::VectorXd &x)
 	{
-		// TODO: missing use_adaptive_barrier_stiffness_ if (use_adaptive_barrier_stiffness_ && is_time_dependent_)
-		// if (inertia_form == nullptr)
-		// 	return;
-
-		// if (contact_form)
-		// 	contact_form->update_barrier_stiffness(x, *nl_problem, friction_form);
-
-		if (contact_form == nullptr)
+		if (contact_form == nullptr || !contact_form->use_adaptive_barrier_stiffness())
 			return;
 
-		if (!contact_form->use_adaptive_barrier_stiffness())
-			return;
-
-		Eigen::VectorXd grad_energy(x.size(), 1);
-		grad_energy.setZero();
-
-		elastic_form->first_derivative(x, grad_energy);
-
-		if (inertia_form)
+		Eigen::VectorXd grad_energy = Eigen::VectorXd::Zero(x.size());
+		const std::array<std::shared_ptr<Form>, 3> energy_forms{
+			{elastic_form, inertia_form, body_form}};
+		for (const std::shared_ptr<Form> &form : energy_forms)
 		{
-			Eigen::VectorXd grad_inertia(x.size());
-			inertia_form->first_derivative(x, grad_inertia);
-			grad_energy += grad_inertia;
-		}
+			if (form == nullptr || !form->enabled())
+				continue;
 
-		Eigen::VectorXd body_energy(x.size());
-		body_form->first_derivative(x, body_energy);
-		grad_energy += body_energy;
+			Eigen::VectorXd grad_form;
+			form->first_derivative(x, grad_form);
+			grad_energy += grad_form;
+		}
 
 		contact_form->update_barrier_stiffness(x, grad_energy);
 	}
 
 	void SolveData::update_dt()
 	{
-		if (time_integrator) // if is time dependent
-		{
-			assert(elastic_form != nullptr);
-			elastic_form->set_weight(time_integrator->acceleration_scaling());
-			if (body_form)
-				body_form->set_weight(time_integrator->acceleration_scaling());
-			if (damping_form)
-				damping_form->set_weight(time_integrator->acceleration_scaling());
+		if (time_integrator == nullptr) // if is not time dependent
+			return;
 
-			// TODO: Determine if friction should be scaled by h²
-			// if (friction_form)
-			// 	friction_form->set_weight(time_integrator->acceleration_scaling());
+		const std::array<std::shared_ptr<Form>, 5> energy_forms{
+			{elastic_form, body_form, damping_form, contact_form, friction_form}};
+		for (const std::shared_ptr<Form> &form : energy_forms)
+		{
+			if (form == nullptr)
+				continue;
+			form->set_weight(time_integrator->acceleration_scaling());
 		}
 	}
 

--- a/src/polyfem/solver/forms/BodyForm.cpp
+++ b/src/polyfem/solver/forms/BodyForm.cpp
@@ -42,6 +42,11 @@ namespace polyfem::solver
 		gradv = -current_rhs_;
 	}
 
+	void BodyForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
+	{
+		hessian.resize(x.size(), x.size());
+	}
+
 	void BodyForm::update_quantities(const double t, const Eigen::VectorXd &x)
 	{
 		this->t_ = t;

--- a/src/polyfem/solver/forms/BodyForm.hpp
+++ b/src/polyfem/solver/forms/BodyForm.hpp
@@ -45,7 +45,7 @@ namespace polyfem::solver
 		/// @brief Compute the second derivative of the value wrt x
 		/// @param[in] x Current solution
 		/// @param[out] hessian Output Hessian of the value wrt x
-		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override { hessian.resize(x.size(), x.size()); }
+		void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const override;
 
 	public:
 		/// @brief Update time dependent quantities

--- a/src/polyfem/solver/forms/ContactForm.hpp
+++ b/src/polyfem/solver/forms/ContactForm.hpp
@@ -28,9 +28,6 @@ namespace ipc
 
 namespace polyfem::solver
 {
-	class NLProblem;
-	class FrictionForm;
-
 	/// @brief Form representing the contact potential and forces
 	class ContactForm : public Form
 	{
@@ -103,62 +100,73 @@ namespace polyfem::solver
 		/// @param x Current solution
 		void post_step(const int iter_num, const Eigen::VectorXd &x) override;
 
-		/// @brief returns the current barrier stiffness
-		/// @return double the current barrier stifness
-		double barrier_stiffness() const { return weight_; }
-
 		/// @brief Checks if the step is collision free
 		/// @return True if the step is collision free else false
 		bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override;
 
 		/// @brief Update the barrier stiffness based on the current elasticity energy
 		/// @param x Current solution
-		/// @param nl_problem Nonlinear problem to use for computing the gradient
-		/// @param friction_form Pointer to the friction form
-		void update_barrier_stiffness(
-			const Eigen::VectorXd &x,
-			NLProblem &nl_problem,
-			std::shared_ptr<FrictionForm> friction_form);
-
-		/// @brief Update the barrier stiffness based on the current elasticity energy
-		/// @param x Current solution
 		void update_barrier_stiffness(const Eigen::VectorXd &x, const Eigen::MatrixXd &grad_energy);
-
-		inline bool use_adaptive_barrier_stiffness() const { return use_adaptive_barrier_stiffness_; }
-		inline bool use_convergent_formulation() const { return constraint_set_.use_convergent_formulation(); }
 
 		/// @brief Compute the displaced positions of the surface nodes
 		Eigen::MatrixXd compute_displaced_surface(const Eigen::VectorXd &x) const;
 
-		bool save_ccd_debug_meshes = false; ///< If true, output debug files
+		/// @brief Get the current barrier stiffness
+		double barrier_stiffness() const { return barrier_stiffness_; }
+		/// @brief Get the current barrier stiffness
+		void set_barrier_stiffness(const double barrier_stiffness) { barrier_stiffness_ = barrier_stiffness; }
+		/// @brief Get use_adaptive_barrier_stiffness
+		bool use_adaptive_barrier_stiffness() const { return use_adaptive_barrier_stiffness_; }
+		/// @brief Get use_convergent_formulation
+		bool use_convergent_formulation() const { return constraint_set_.use_convergent_formulation(); }
+
+		double weight() const override { return weight_ * barrier_stiffness_; }
+
+		/// @brief If true, output debug files
+		bool save_ccd_debug_meshes = false;
 
 	private:
-		const ipc::CollisionMesh &collision_mesh_;
-
-		const double dhat_; ///< Barrier activation distance
-
-		// TODO: Make this a parameter
-		const double dmin_ = 0; ///< Minimum distance between elements
-
-		const double avg_mass_;
-
-		const bool use_adaptive_barrier_stiffness_; ///< If true, use an adaptive barrier stiffness
-		double max_barrier_stiffness_;              ///< Maximum barrier stiffness to use when using adaptive barrier stiffness
-
-		const bool is_time_dependent_; ///< Is the simulation time dependent?
-
-		const ipc::BroadPhaseMethod broad_phase_method_; ///< Broad phase method to use for distance and CCD evaluations
-		const double ccd_tolerance_;                     ///< Continuous collision detection tolerance
-		const int ccd_max_iterations_;                   ///< Continuous collision detection maximum iterations
-
-		double prev_distance_; ///< Previous minimum distance between all elements
-
-		bool use_cached_candidates_ = false;       ///< If true, use the cached candidate set for the current solution
-		ipc::CollisionConstraints constraint_set_; ///< Cached constraint set for the current solution
-		ipc::Candidates candidates_;               ///< Cached candidate set for the current solution
-
 		/// @brief Update the cached candidate set for the current solution
 		/// @param displaced_surface Vertex positions displaced by the current solution
 		void update_constraint_set(const Eigen::MatrixXd &displaced_surface);
+
+		/// @brief Collision mesh
+		const ipc::CollisionMesh &collision_mesh_;
+
+		/// @brief Barrier activation distance
+		const double dhat_;
+
+		/// @brief Minimum distance between elements
+		const double dmin_ = 0;
+
+		/// @brief If true, use an adaptive barrier stiffness
+		const bool use_adaptive_barrier_stiffness_;
+		/// @brief Barrier stiffness
+		double barrier_stiffness_;
+		/// @brief Maximum barrier stiffness to use when using adaptive barrier stiffness
+		double max_barrier_stiffness_;
+
+		/// @brief Average mass of the mesh (used for adaptive barrier stiffness)
+		const double avg_mass_;
+
+		/// @brief Is the simulation time dependent?
+		const bool is_time_dependent_;
+
+		/// @brief Broad phase method to use for distance and CCD evaluations
+		const ipc::BroadPhaseMethod broad_phase_method_;
+		/// @brief Continuous collision detection tolerance
+		const double ccd_tolerance_;
+		/// @brief Continuous collision detection maximum iterations
+		const int ccd_max_iterations_;
+
+		/// @brief Previous minimum distance between all elements
+		double prev_distance_;
+
+		/// @brief If true, use the cached candidate set for the current solution
+		bool use_cached_candidates_ = false;
+		/// @brief Cached constraint set for the current solution
+		ipc::CollisionConstraints constraint_set_;
+		/// @brief Cached candidate set for the current solution
+		ipc::Candidates candidates_;
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/Form.hpp
+++ b/src/polyfem/solver/forms/Form.hpp
@@ -133,7 +133,7 @@ namespace polyfem::solver
 	protected:
 		bool project_to_psd_ = false; ///< If true, the form's second derivative is projected to be positive semidefinite
 
-		double weight_ = 1; ///< weight of the form (e.g., AL penalty weight or Δtꜝ)
+		double weight_ = 1; ///< weight of the form (e.g., AL penalty weight or Δt²)
 
 		bool enabled_ = true; ///< If true, the form is enabled
 

--- a/src/polyfem/solver/forms/Form.hpp
+++ b/src/polyfem/solver/forms/Form.hpp
@@ -20,7 +20,7 @@ namespace polyfem::solver
 		/// @return Computed value
 		inline double value(const Eigen::VectorXd &x) const
 		{
-			return weight_ * value_unweighted(x);
+			return weight() * value_unweighted(x);
 		}
 
 		/// @brief Compute the first derivative of the value wrt x multiplied with the weigth
@@ -29,7 +29,7 @@ namespace polyfem::solver
 		inline void first_derivative(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 		{
 			first_derivative_unweighted(x, gradv);
-			gradv *= weight_;
+			gradv *= weight();
 		}
 
 		/// @brief Compute the second derivative of the value wrt x multiplied with the weigth
@@ -39,7 +39,7 @@ namespace polyfem::solver
 		inline void second_derivative(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const
 		{
 			second_derivative_unweighted(x, hessian);
-			hessian *= weight_;
+			hessian *= weight();
 		}
 
 		/// @brief Determine if a step from solution x0 to solution x1 is allowed
@@ -111,7 +111,7 @@ namespace polyfem::solver
 		bool enabled() const { return enabled_; }
 
 		/// @brief Get the form's multiplicative constant weight
-		double weight() const { return weight_; }
+		virtual double weight() const { return weight_; }
 
 		/// @brief Set the form's multiplicative constant weight
 		/// @param weight New weight to use
@@ -133,7 +133,7 @@ namespace polyfem::solver
 	protected:
 		bool project_to_psd_ = false; ///< If true, the form's second derivative is projected to be positive semidefinite
 
-		double weight_ = 1; ///< weight of the form, eg barrier stiffness, AL, d^2
+		double weight_ = 1; ///< weight of the form (e.g., AL penalty weight or Δtꜝ)
 
 		bool enabled_ = true; ///< If true, the form is enabled
 


### PR DESCRIPTION
I also put the acceleration scaling into the non-convergent formulation, but I adjust the adaptive barrier stiffness so the extra scaling burns off.