### PR TITLE
Fix File Log Level

### DIFF
--- a/src/polyfem/state/StateInit.cpp
+++ b/src/polyfem/state/StateInit.cpp
@@ -122,12 +122,18 @@ namespace polyfem
 
 	void State::set_log_level(const spdlog::level::level_enum log_level)
 	{
-		// Set only the level of the console
 		spdlog::set_level(log_level);
-		logger().set_level(log_level);
-		ipc::logger().set_level(log_level);
 		if (console_sink_)
+		{
+			// Set only the level of the console
 			console_sink_->set_level(log_level); // Shared by all loggers
+		}
+		else
+		{
+			// Set the level of all loggers
+			logger().set_level(log_level);
+			ipc::logger().set_level(log_level);
+		}
 	}
 
 	void State::init(const json &p_args_in, const bool strict_validation)

--- a/src/polyfem/state/StateInit.cpp
+++ b/src/polyfem/state/StateInit.cpp
@@ -130,7 +130,7 @@ namespace polyfem
 		}
 		else
 		{
-			// Set the level of all loggers
+			// Set the level of all sinks
 			logger().set_level(log_level);
 			ipc::logger().set_level(log_level);
 		}


### PR DESCRIPTION
The file-specific log level was broken at some point. This re-enables it.

Problem: `logger()` and `ipc::logger()` both share the `console_sink_` and `file_sink_`, so using `logger().set_level(...)` overrides the level for both `console_sink_` and `file_sink_`. 

Solution: To get different log levels for `console_sink_` and `file_sink_` we should only change `console_sink_` in `State::set_log_level` and leave `file_sink_`'s level fixed.