### PR TITLE
fix bug for mooney rivlin in 2D

### DIFF
--- a/src/polyfem/assembler/MooneyRivlin3ParamElasticity.hpp
+++ b/src/polyfem/assembler/MooneyRivlin3ParamElasticity.hpp
@@ -35,7 +35,6 @@ namespace polyfem::assembler
 			const double d1 = d1_(p, t, el_id);
 
 			const T J = polyfem::utils::determinant(def_grad);
-			const T log_J = log(J);
 			const auto right_cauchy_green = def_grad * def_grad.transpose();
 
 			const auto powJ = pow(J, -2. / 3);
@@ -44,7 +43,7 @@ namespace polyfem::assembler
 			const auto second_invariant_val = (size() == 3) ? 0.5 * (TrB * TrB - (right_cauchy_green * right_cauchy_green).trace()) : TrB + J * J;
 			const auto I2_tilde = (powJ * powJ) * second_invariant_val - 3;
 
-			const T val = c1 * I1_tilde + (c2 + c3 * I1_tilde) * I2_tilde + d1 * log_J * log_J;
+			const T val = c1 * I1_tilde + (c2 + c3 * I1_tilde) * I2_tilde + d1 * (J - 1) * (J - 1);
 
 			return val;
 		}

--- a/src/polyfem/assembler/MooneyRivlin3ParamElasticity.hpp
+++ b/src/polyfem/assembler/MooneyRivlin3ParamElasticity.hpp
@@ -36,13 +36,15 @@ namespace polyfem::assembler
 
 			const T J = polyfem::utils::determinant(def_grad);
 			const T log_J = log(J);
+			const auto right_cauchy_green = def_grad * def_grad.transpose();
 
-			const auto F_tilde = def_grad / pow(J, 1.0 / size());
-			const auto C_tilde = F_tilde * F_tilde.transpose();
-			const auto I1_tilde = first_invariant(C_tilde);
-			const auto I2_tilde = second_invariant(C_tilde);
+			const auto powJ = pow(J, -2. / 3);
+			const auto TrB = right_cauchy_green.trace();
+			const auto I1_tilde = powJ * (TrB + (3 - size())) - 3;
+			const auto second_invariant_val = (size() == 3) ? 0.5 * (TrB * TrB - (right_cauchy_green * right_cauchy_green).trace()) : TrB + J * J;
+			const auto I2_tilde = (powJ * powJ) * second_invariant_val - 3;
 
-			const T val = c1 * (I1_tilde - size()) + c2 * (I2_tilde - size()) + c3 * (I1_tilde - size()) * (I2_tilde - size()) + d1 * (J - 1) * (J - 1);
+			const T val = c1 * I1_tilde + (c2 + c3 * I1_tilde) * I2_tilde + d1 * log_J * log_J;
 
 			return val;
 		}


### PR DESCRIPTION
The old 2D Mooney-Rivlin was wrongly inferred from the 3D version -- it is not zero at rest pose and can be negative. The fixed version now is by assuming the deformation gradient is 0,0,1 in the 3rd dimension.