### PR TITLE
Update IPC Toolkit

### DIFF
--- a/cmake/recipes/ipc_toolkit.cmake
+++ b/cmake/recipes/ipc_toolkit.cmake
@@ -8,4 +8,4 @@ endif()
 message(STATUS "Third-party: creating target 'ipc::toolkit'")
 
 include(CPM)
-CPMAddPackage("gh:ipc-sim/ipc-toolkit#8532c5f1544ca798789c26deaa9da1c7cd2dfc76")
+CPMAddPackage("gh:ipc-sim/ipc-toolkit#e3707832f83f5576c07e3bb9f748a4c75835ca85")

--- a/json-specs/input-spec.json
+++ b/json-specs/input-spec.json
@@ -1401,10 +1401,10 @@
             "SH",
             "bvh",
             "BVH",
+            "sweep_and_prune",
+            "SAP",
             "sweep_and_tiniest_queue",
-            "STQ",
-            "sweep_and_tiniest_queue_gpu",
-            "STQ_GPU"
+            "STQ"
         ],
         "doc": "Broad phase collision-detection algorithm to use"
     },

--- a/src/polyfem/io/OutData.cpp
+++ b/src/polyfem/io/OutData.cpp
@@ -1999,7 +1999,7 @@ namespace polyfem::io
 				ipc::FrictionCollisions friction_collision_set;
 				friction_collision_set.build(
 					collision_mesh, displaced_surface, collision_set,
-					dhat, barrier_stiffness, friction_coefficient);
+					barrier_potential, barrier_stiffness, friction_coefficient);
 
 				ipc::FrictionPotential friction_potential(epsv);
 

--- a/src/polyfem/solver/AdjointTools.cpp
+++ b/src/polyfem/solver/AdjointTools.cpp
@@ -819,13 +819,13 @@ namespace polyfem::solver
 				const Eigen::MatrixXd surface_velocities = (surface_solution - surface_solution_prev) / dt;
 
 				Eigen::MatrixXd force = state.collision_mesh.to_full_dof(
-					-state.solve_data.friction_form->get_friction_potential().force(
+					-state.solve_data.friction_form->friction_potential().force(
 						state.diff_cached.friction_collision_set(t),
 						state.collision_mesh,
 						state.collision_mesh.rest_positions(),
 						/*lagged_displacements=*/surface_solution_prev,
 						surface_velocities,
-						state.solve_data.contact_form->dhat(),
+						state.solve_data.contact_form->barrier_potential(),
 						state.solve_data.contact_form->barrier_stiffness(),
 						state.solve_data.friction_form->epsv()));
 

--- a/src/polyfem/solver/SolveData.cpp
+++ b/src/polyfem/solver/SolveData.cpp
@@ -183,7 +183,7 @@ namespace polyfem::solver
 			if (friction_coefficient != 0)
 			{
 				friction_form = std::make_shared<FrictionForm>(
-					collision_mesh, time_integrator, epsv, friction_coefficient, dhat,
+					collision_mesh, time_integrator, epsv, friction_coefficient,
 					broad_phase, *contact_form, friction_iterations);
 				friction_form->init_lagging(sol);
 				forms.push_back(friction_form);

--- a/src/polyfem/solver/forms/ContactForm.cpp
+++ b/src/polyfem/solver/forms/ContactForm.cpp
@@ -230,7 +230,7 @@ namespace polyfem::solver
 		}
 
 		double max_step;
-		if (use_cached_candidates_ && broad_phase_method_ != ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU)
+		if (use_cached_candidates_ && broad_phase_method_ != ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE)
 			max_step = candidates_.compute_collision_free_stepsize(
 				collision_mesh_, V0, V1, dmin_, ccd_tolerance_, ccd_max_iterations_);
 		else

--- a/src/polyfem/solver/forms/ContactForm.hpp
+++ b/src/polyfem/solver/forms/ContactForm.hpp
@@ -23,10 +23,10 @@ namespace ipc
 		 {ipc::BroadPhaseMethod::SPATIAL_HASH, "SH"},
 		 {ipc::BroadPhaseMethod::BVH, "bvh"},
 		 {ipc::BroadPhaseMethod::BVH, "BVH"},
+		 {ipc::BroadPhaseMethod::SWEEP_AND_PRUNE, "sweep_and_prune"},
+		 {ipc::BroadPhaseMethod::SWEEP_AND_PRUNE, "SAP"},
 		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "sweep_and_tiniest_queue"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "STQ"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "sweep_and_tiniest_queue_gpu"},
-		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE_GPU, "STQ_GPU"}})
+		 {ipc::BroadPhaseMethod::SWEEP_AND_TINIEST_QUEUE, "STQ"}})
 } // namespace ipc
 
 namespace polyfem::solver
@@ -141,9 +141,8 @@ namespace polyfem::solver
 		bool save_ccd_debug_meshes = false;
 
 		double dhat() const { return dhat_; }
-		ipc::Collisions get_collision_set() const { return collision_set_; }
-
-		const ipc::BarrierPotential &get_barrier_potential() const { return barrier_potential_; }
+		const ipc::Collisions &collision_set() const { return collision_set_; }
+		const ipc::BarrierPotential &barrier_potential() const { return barrier_potential_; }
 
 	protected:
 		/// @brief Update the cached candidate set for the current solution

--- a/src/polyfem/solver/forms/FrictionForm.cpp
+++ b/src/polyfem/solver/forms/FrictionForm.cpp
@@ -11,7 +11,6 @@ namespace polyfem::solver
 		const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator,
 		const double epsv,
 		const double mu,
-		const double dhat,
 		const ipc::BroadPhaseMethod broad_phase_method,
 		const ContactForm &contact_form,
 		const int n_lagging_iters)
@@ -19,12 +18,10 @@ namespace polyfem::solver
 		  time_integrator_(time_integrator),
 		  epsv_(epsv),
 		  mu_(mu),
-		  dhat_(dhat),
 		  broad_phase_method_(broad_phase_method),
 		  n_lagging_iters_(n_lagging_iters < 0 ? std::numeric_limits<int>::max() : n_lagging_iters),
 		  contact_form_(contact_form),
 		  friction_potential_(epsv)
-
 	{
 		assert(epsv_ > 0);
 	}
@@ -46,7 +43,8 @@ namespace polyfem::solver
 			friction_constraints_set,
 			collision_mesh_, collision_mesh_.rest_positions(),
 			/*lagged_displacements=*/U_prev, velocities,
-			dhat_, contact_form_.barrier_stiffness(),
+			contact_form_.barrier_potential(),
+			contact_form_.barrier_stiffness(),
 			ipc::FrictionPotential::DiffWRT::REST_POSITIONS);
 
 		// {
@@ -134,11 +132,10 @@ namespace polyfem::solver
 		collision_set.set_use_convergent_formulation(contact_form_.use_convergent_formulation());
 		collision_set.set_are_shape_derivatives_enabled(contact_form_.enable_shape_derivatives());
 		collision_set.build(
-			collision_mesh_, displaced_surface, dhat_,
-			/*dmin=*/0, broad_phase_method_);
+			collision_mesh_, displaced_surface, contact_form_.dhat(), /*dmin=*/0, broad_phase_method_);
 
 		friction_collision_set_.build(
 			collision_mesh_, displaced_surface, collision_set,
-			contact_form_.get_barrier_potential(), contact_form_.barrier_stiffness(), mu_);
+			contact_form_.barrier_potential(), contact_form_.barrier_stiffness(), mu_);
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/FrictionForm.hpp
+++ b/src/polyfem/solver/forms/FrictionForm.hpp
@@ -32,7 +32,6 @@ namespace polyfem::solver
 			const std::shared_ptr<time_integrator::ImplicitTimeIntegrator> time_integrator,
 			const double epsv,
 			const double mu,
-			const double dhat,
 			const ipc::BroadPhaseMethod broad_phase_method,
 			const ContactForm &contact_form,
 			const int n_lagging_iters);
@@ -86,9 +85,8 @@ namespace polyfem::solver
 
 		double mu() const { return mu_; }
 		double epsv() const { return epsv_; }
-		ipc::FrictionCollisions get_friction_collision_set() const { return friction_collision_set_; }
-
-		const ipc::FrictionPotential &get_friction_potential() const { return friction_potential_; }
+		const ipc::FrictionCollisions &friction_collision_set() const { return friction_collision_set_; }
+		const ipc::FrictionPotential &friction_potential() const { return friction_potential_; }
 
 	private:
 		/// Reference to the collision mesh
@@ -99,7 +97,6 @@ namespace polyfem::solver
 
 		const double epsv_;                              ///< Smoothing factor between static and dynamic friction
 		const double mu_;                                ///< Global coefficient of friction
-		const double dhat_;                              ///< Barrier activation distance
 		const ipc::BroadPhaseMethod broad_phase_method_; ///< Broad-phase method used for distance computation and collision detection
 		const int n_lagging_iters_;                      ///< Number of lagging iterations
 

--- a/src/polyfem/state/StateDiff.cpp
+++ b/src/polyfem/state/StateDiff.cpp
@@ -110,8 +110,8 @@ namespace polyfem
 			if (!problem->is_time_dependent() || current_step > 0)
 				compute_force_jacobian(sol, disp_grad, gradu_h);
 
-			cur_collision_set = solve_data.contact_form ? solve_data.contact_form->get_collision_set() : ipc::Collisions();
-			cur_friction_set = solve_data.friction_form ? solve_data.friction_form->get_friction_collision_set() : ipc::FrictionCollisions();
+			cur_collision_set = solve_data.contact_form ? solve_data.contact_form->collision_set() : ipc::Collisions();
+			cur_friction_set = solve_data.friction_form ? solve_data.friction_form->friction_collision_set() : ipc::FrictionCollisions();
 		}
 		else
 		{
@@ -218,22 +218,22 @@ namespace polyfem
 						const double dv_dut = -1 / dt;
 
 						hessian_prev =
-							solve_data.friction_form->get_friction_potential().force_jacobian(
+							solve_data.friction_form->friction_potential().force_jacobian(
 								diff_cached.friction_collision_set(force_step),
 								collision_mesh,
 								collision_mesh.rest_positions(),
 								/*lagged_displacements=*/surface_solution_prev,
 								surface_velocities,
-								solve_data.contact_form->dhat(),
+								solve_data.contact_form->barrier_potential(),
 								solve_data.contact_form->barrier_stiffness(),
 								ipc::FrictionPotential::DiffWRT::LAGGED_DISPLACEMENTS)
-							+ solve_data.friction_form->get_friction_potential().force_jacobian(
+							+ solve_data.friction_form->friction_potential().force_jacobian(
 								  diff_cached.friction_collision_set(force_step),
 								  collision_mesh,
 								  collision_mesh.rest_positions(),
 								  /*lagged_displacements=*/surface_solution_prev,
 								  surface_velocities,
-								  solve_data.contact_form->dhat(),
+								  solve_data.contact_form->barrier_potential(),
 								  solve_data.contact_form->barrier_stiffness(),
 								  ipc::FrictionPotential::DiffWRT::VELOCITIES)
 								  * dv_dut;

--- a/tests/test_form_derivatives.cpp
+++ b/tests/test_form_derivatives.cpp
@@ -303,8 +303,8 @@ TEST_CASE("friction form derivatives", "[form][form_derivatives][friction_form]"
 		ccd_tolerance, ccd_max_iterations);
 
 	FrictionForm form(
-		state_ptr->collision_mesh, nullptr, epsv, mu, dhat, broad_phase_method,
-		contact_form, /*n_lagging_iters=*/-1);
+		state_ptr->collision_mesh, nullptr, epsv, mu, broad_phase_method, contact_form,
+		/*n_lagging_iters=*/-1);
 
 	test_form(form, *state_ptr);
 }


### PR DESCRIPTION
Update IPC Toolkit from [8532c5](https://github.com/ipc-sim/ipc-toolkit/commit/8532c5f1544ca798789c26deaa9da1c7cd2dfc76) to [e37078](https://github.com/ipc-sim/ipc-toolkit/commit/e3707832f83f5576c07e3bb9f748a4c75835ca85).

* `SWEEP_AND_TINIEST_QUEUE` -> `SWEEP_AND_PRUNE`
* `SWEEP_AND_TINIEST_QUEUE_GPU` -> `SWEEP_AND_TINIEST_QUEUE`
* SAP and STQ now support all collision types (i.e., 2D and intersection checks added)
* Remove implicit conversion from `dhat` to `BarrierPotential`