### PR TITLE
Differentiable refactor

### DIFF
--- a/json-specs/opt-input-spec.json
+++ b/json-specs/opt-input-spec.json
@@ -60,7 +60,8 @@
         "optional": [
             "log",
             "save_frequency",
-            "directory"
+            "directory",
+            "solution"
         ],
         "doc": "Optimization output options"
     },
@@ -81,6 +82,12 @@
         "spec_file": "log.json",
         "type": "include",
         "doc": "Setting for the output log."
+    },
+    {
+        "pointer": "/output/solution",
+        "default": "",
+        "type": "file",
+        "doc": "Export optimization variables to file at every iteration."
     },
     {
         "pointer": "/solver",

--- a/src/polyfem/OptState.cpp
+++ b/src/polyfem/OptState.cpp
@@ -150,13 +150,7 @@ namespace polyfem
 		}
 
 		/* variable to simulations */
-		variable_to_simulations.clear();
-		for (const auto &arg : args["variable_to_simulation"])
-			variable_to_simulations.push_back(
-				solver::AdjointOptUtils::create_variable_to_simulation(
-					arg,
-					states,
-					variable_sizes));
+		variable_to_simulations.init(args["variable_to_simulation"], states, variable_sizes);
 	}
 
 	void OptState::crate_problem()
@@ -179,8 +173,7 @@ namespace polyfem
 	{
 		x = solver::AdjointOptUtils::inverse_evaluation(args["parameters"], ndof, variable_sizes, variable_to_simulations);
 
-		for (auto &v2s : variable_to_simulations)
-			v2s->update(x);
+		variable_to_simulations.update(x);
 	}
 
 	double OptState::eval(Eigen::VectorXd &x) const

--- a/src/polyfem/OptState.cpp
+++ b/src/polyfem/OptState.cpp
@@ -36,6 +36,11 @@ namespace spdlog::level
 
 namespace polyfem
 {
+	OptState::~OptState()
+	{
+
+	}
+
 	OptState::OptState()
 	{
 		utils::GeogramUtils::instance().initialize();
@@ -166,7 +171,7 @@ namespace polyfem
 			stopping_conditions.push_back(
 				solver::AdjointOptUtils::create_form(arg, variable_to_simulations, states));
 
-		nl_problem = std::make_shared<solver::AdjointNLProblem>(
+		nl_problem = std::make_unique<solver::AdjointNLProblem>(
 			obj, stopping_conditions, variable_to_simulations, states, args);
 	}
 

--- a/src/polyfem/OptState.hpp
+++ b/src/polyfem/OptState.hpp
@@ -6,6 +6,7 @@
 #include <polyfem/utils/Logger.hpp>
 
 #include <polyfem/solver/DiffCache.hpp>
+#include <polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp>
 
 namespace polyfem
 {
@@ -13,7 +14,6 @@ namespace polyfem
 
 	namespace solver
 	{
-		class VariableToSimulation;
 		class AdjointNLProblem;
 	} // namespace solver
 
@@ -97,7 +97,7 @@ namespace polyfem
 		std::vector<int> variable_sizes;
 		int ndof;
 
-		std::vector<std::unique_ptr<solver::VariableToSimulation>> variable_to_simulations;
+		solver::VariableToSimulationGroup variable_to_simulations;
 
 		std::unique_ptr<solver::AdjointNLProblem> nl_problem;
 

--- a/src/polyfem/OptState.hpp
+++ b/src/polyfem/OptState.hpp
@@ -25,7 +25,7 @@ namespace polyfem
 		//-----------------initialization--------------------
 		//---------------------------------------------------
 
-		~OptState() = default;
+		~OptState();
 		/// Constructor
 		OptState();
 
@@ -97,9 +97,9 @@ namespace polyfem
 		std::vector<int> variable_sizes;
 		int ndof;
 
-		std::vector<std::shared_ptr<solver::VariableToSimulation>> variable_to_simulations;
+		std::vector<std::unique_ptr<solver::VariableToSimulation>> variable_to_simulations;
 
-		std::shared_ptr<solver::AdjointNLProblem> nl_problem;
+		std::unique_ptr<solver::AdjointNLProblem> nl_problem;
 
 	public:
 		/// Directory for output files

--- a/src/polyfem/io/Evaluator.cpp
+++ b/src/polyfem/io/Evaluator.cpp
@@ -291,7 +291,7 @@ namespace polyfem::io
 				const int face_id = mesh3d.cell_face(e, lf);
 				// if (!mesh3d.is_boundary_face(face_id))
 				//     continue;
-				int I;
+				int I = -1;
 				Eigen::RowVector3d C;
 				const Eigen::RowVector3d bary = mesh3d.face_barycenter(face_id);
 

--- a/src/polyfem/io/OutData.hpp
+++ b/src/polyfem/io/OutData.hpp
@@ -515,8 +515,8 @@ namespace polyfem::io
 		void write(const int i, const Eigen::MatrixXd &sol);
 
 	protected:
-		const solver::SolveData &solve_data;
 		std::ofstream file;
+		const solver::SolveData &solve_data;
 	};
 
 	class RuntimeStatsCSVWriter
@@ -528,10 +528,10 @@ namespace polyfem::io
 		void write(const int t, const double forward, const double remeshing, const double global_relaxation, const Eigen::MatrixXd &sol);
 
 	protected:
+		std::ofstream file;
 		const State &state;
 		const double t0;
 		const double dt;
-		std::ofstream file;
 		double total_forward_solve_time = 0;
 		double total_remeshing_time = 0;
 		double total_global_relaxation_time = 0;

--- a/src/polyfem/solver/AdjointNLProblem.cpp
+++ b/src/polyfem/solver/AdjointNLProblem.cpp
@@ -257,27 +257,6 @@ namespace polyfem::solver
 		}
 	}
 
-	// void AdjointNLProblem::solution_changed_no_solve(const Eigen::VectorXd &newX)
-	// {
-	// 	bool need_rebuild_basis = false;
-
-	// 	// update to new parameter and check if the new parameter is valid to solve
-	// 	for (const auto &v : variables_to_simulation_)
-	// 	{
-	// 		v->update(newX);
-	// 		if (v->get_parameter_type() == ParameterType::Shape)
-	// 			need_rebuild_basis = true;
-	// 	}
-
-	// 	if (need_rebuild_basis)
-	// 	{
-	// 		for (const auto &state : all_states_)
-	// 			state->build_basis();
-	// 	}
-
-	// 	form_->solution_changed(newX);
-	// }
-
 	void AdjointNLProblem::solution_changed(const Eigen::VectorXd &newX)
 	{
 		bool need_rebuild_basis = false;

--- a/src/polyfem/solver/AdjointNLProblem.cpp
+++ b/src/polyfem/solver/AdjointNLProblem.cpp
@@ -95,7 +95,7 @@ namespace polyfem::solver
 		}
 	} // namespace
 
-	AdjointNLProblem::AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args)
+	AdjointNLProblem::AdjointNLProblem(std::shared_ptr<AdjointForm> form, const VariableToSimulationGroup &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args)
 		: FullNLProblem({form}),
 		  form_(form),
 		  variables_to_simulation_(variables_to_simulation),
@@ -135,7 +135,7 @@ namespace polyfem::solver
 		}
 	}
 
-	AdjointNLProblem::AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args) : AdjointNLProblem(form, variables_to_simulation, all_states, args)
+	AdjointNLProblem::AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const VariableToSimulationGroup &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args) : AdjointNLProblem(form, variables_to_simulation, all_states, args)
 	{
 		stopping_conditions_ = stopping_conditions;
 	}

--- a/src/polyfem/solver/AdjointNLProblem.cpp
+++ b/src/polyfem/solver/AdjointNLProblem.cpp
@@ -161,7 +161,7 @@ namespace polyfem::solver
 			{
 				POLYFEM_SCOPED_TIMER("adjoint solve");
 				for (int i = 0; i < all_states_.size(); i++)
-					all_states_[i]->solve_adjoint_cached(form_->compute_adjoint_rhs(x, *all_states_[i])); // caches inside state
+					all_states_[i]->solve_adjoint_cached(form_->compute_reduced_adjoint_rhs(x, *all_states_[i])); // caches inside state
 			}
 
 			{

--- a/src/polyfem/solver/AdjointNLProblem.cpp
+++ b/src/polyfem/solver/AdjointNLProblem.cpp
@@ -105,6 +105,13 @@ namespace polyfem::solver
 	{
 		cur_grad.setZero(0);
 
+		if (args["output"]["solution"] != "")
+		{
+			solution_ostream.open(args["output"]["solution"], std::ofstream::out);
+			if (!solution_ostream.is_open())
+				adjoint_logger().error("Cannot open solution file for writing!");
+		}
+
 		solve_in_order.clear();
 		{
 			Graph G(all_states.size());
@@ -208,6 +215,14 @@ namespace polyfem::solver
 	void AdjointNLProblem::save_to_file(const int iter_num, const Eigen::VectorXd &x0)
 	{
 		int id = 0;
+
+		if (solution_ostream.is_open())
+		{
+			adjoint_logger().debug("Save solution at iteration {} to file...", iter_num);
+			solution_ostream << iter_num << ": " << std::setprecision(16) << x0.transpose() << std::endl;
+			solution_ostream.flush();
+		}
+
 		if (iter_num % save_freq != 0)
 			return;
 		adjoint_logger().info("Saving iteration {}", iter_num);

--- a/src/polyfem/solver/AdjointNLProblem.cpp
+++ b/src/polyfem/solver/AdjointNLProblem.cpp
@@ -107,7 +107,7 @@ namespace polyfem::solver
 
 		if (args["output"]["solution"] != "")
 		{
-			solution_ostream.open(args["output"]["solution"], std::ofstream::out);
+			solution_ostream.open(args["output"]["solution"].get<std::string>(), std::ofstream::out);
 			if (!solution_ostream.is_open())
 				adjoint_logger().error("Cannot open solution file for writing!");
 		}

--- a/src/polyfem/solver/AdjointNLProblem.hpp
+++ b/src/polyfem/solver/AdjointNLProblem.hpp
@@ -17,8 +17,8 @@ namespace polyfem::solver
 	class AdjointNLProblem : public FullNLProblem
 	{
 	public:
-		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
-		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const std::vector<std::shared_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
+		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
+		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
 
 		double value(const Eigen::VectorXd &x) override;
 
@@ -37,16 +37,16 @@ namespace polyfem::solver
 		// virtual void set_project_to_psd(bool val) override;
 
 		void solution_changed(const Eigen::VectorXd &new_x) override;
-		void solution_changed_no_solve(const Eigen::VectorXd &new_x);
+		// void solution_changed_no_solve(const Eigen::VectorXd &new_x);
 
 		void solve_pde();
 
-		int n_states() const { return all_states_.size(); }
-		std::shared_ptr<State> get_state(int id) { return all_states_[id]; }
+		// int n_states() const { return all_states_.size(); }
+		// std::shared_ptr<State> get_state(int id) { return all_states_[id]; }
 
 	private:
 		std::shared_ptr<AdjointForm> form_;
-		std::vector<std::shared_ptr<VariableToSimulation>> variables_to_simulation_;
+		const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation_;
 		std::vector<std::shared_ptr<State>> all_states_;
 		std::vector<bool> active_state_mask;
 		Eigen::VectorXd cur_grad;

--- a/src/polyfem/solver/AdjointNLProblem.hpp
+++ b/src/polyfem/solver/AdjointNLProblem.hpp
@@ -4,6 +4,7 @@
 #include <polyfem/Common.hpp>
 #include "FullNLProblem.hpp"
 #include <polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp>
+#include <fstream>
 
 namespace polyfem
 {
@@ -45,6 +46,7 @@ namespace polyfem::solver
 		Eigen::VectorXd cur_grad;
 
 		const int save_freq;
+		std::ofstream solution_ostream;
 
 		const bool solve_in_parallel;
 		std::vector<int> solve_in_order;

--- a/src/polyfem/solver/AdjointNLProblem.hpp
+++ b/src/polyfem/solver/AdjointNLProblem.hpp
@@ -34,16 +34,9 @@ namespace polyfem::solver
 		void post_step(const polysolve::nonlinear::PostStepData &data) override;
 		bool stop(const TVector &x) override;
 
-		// virtual void set_project_to_psd(bool val) override;
-
 		void solution_changed(const Eigen::VectorXd &new_x) override;
-		// void solution_changed_no_solve(const Eigen::VectorXd &new_x);
-
 		void solve_pde();
-
-		// int n_states() const { return all_states_.size(); }
-		// std::shared_ptr<State> get_state(int id) { return all_states_[id]; }
-
+		
 	private:
 		std::shared_ptr<AdjointForm> form_;
 		const VariableToSimulationGroup variables_to_simulation_;

--- a/src/polyfem/solver/AdjointNLProblem.hpp
+++ b/src/polyfem/solver/AdjointNLProblem.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <polyfem/Common.hpp>
 #include "FullNLProblem.hpp"
+#include <polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp>
 
 namespace polyfem
 {
@@ -12,13 +13,12 @@ namespace polyfem
 namespace polyfem::solver
 {
 	class AdjointForm;
-	class VariableToSimulation;
 
 	class AdjointNLProblem : public FullNLProblem
 	{
 	public:
-		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
-		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
+		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const VariableToSimulationGroup &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
+		AdjointNLProblem(std::shared_ptr<AdjointForm> form, const std::vector<std::shared_ptr<AdjointForm>> stopping_conditions, const VariableToSimulationGroup &variables_to_simulation, const std::vector<std::shared_ptr<State>> &all_states, const json &args);
 
 		double value(const Eigen::VectorXd &x) override;
 
@@ -46,7 +46,7 @@ namespace polyfem::solver
 
 	private:
 		std::shared_ptr<AdjointForm> form_;
-		const std::vector<std::unique_ptr<VariableToSimulation>> &variables_to_simulation_;
+		const VariableToSimulationGroup variables_to_simulation_;
 		std::vector<std::shared_ptr<State>> all_states_;
 		std::vector<bool> active_state_mask;
 		Eigen::VectorXd cur_grad;

--- a/src/polyfem/solver/AdjointTools.cpp
+++ b/src/polyfem/solver/AdjointTools.cpp
@@ -191,7 +191,7 @@ namespace polyfem::solver
 		const double dt = state.problem->is_time_dependent() ? state.args["time"]["dt"].get<double>() : 0.0;
 
 		double integral = 0;
-		if (spatial_integral_type == SpatialIntegralType::volume)
+		if (spatial_integral_type == SpatialIntegralType::Volume)
 		{
 			auto storage = utils::create_thread_storage(LocalThreadScalarStorage());
 			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
@@ -228,7 +228,7 @@ namespace polyfem::solver
 			for (const LocalThreadScalarStorage &local_storage : storage)
 				integral += local_storage.val;
 		}
-		else if (spatial_integral_type == SpatialIntegralType::surface)
+		else if (spatial_integral_type == SpatialIntegralType::Surface)
 		{
 			auto storage = utils::create_thread_storage(LocalThreadScalarStorage());
 			utils::maybe_parallel_for(state.total_local_boundary.size(), [&](int start, int end, int thread_id) {
@@ -275,7 +275,7 @@ namespace polyfem::solver
 			for (const LocalThreadScalarStorage &local_storage : storage)
 				integral += local_storage.val;
 		}
-		else if (spatial_integral_type == SpatialIntegralType::vertex_sum)
+		else if (spatial_integral_type == SpatialIntegralType::VertexSum)
 		{
 			std::vector<bool> traversed(state.n_bases, false);
 			IntegrableFunctional::ParameterType params;
@@ -329,7 +329,7 @@ namespace polyfem::solver
 
 		auto storage = utils::create_thread_storage(LocalThreadVecStorage(term.size()));
 
-		if (spatial_integral_type == SpatialIntegralType::volume)
+		if (spatial_integral_type == SpatialIntegralType::Volume)
 		{
 			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
 				LocalThreadVecStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
@@ -398,7 +398,7 @@ namespace polyfem::solver
 				}
 			});
 		}
-		else if (spatial_integral_type == SpatialIntegralType::surface)
+		else if (spatial_integral_type == SpatialIntegralType::Surface)
 		{
 			utils::maybe_parallel_for(state.total_local_boundary.size(), [&](int start, int end, int thread_id) {
 				LocalThreadVecStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
@@ -532,7 +532,7 @@ namespace polyfem::solver
 				}
 			});
 		}
-		else if (spatial_integral_type == SpatialIntegralType::vertex_sum)
+		else if (spatial_integral_type == SpatialIntegralType::VertexSum)
 		{
 			log_and_throw_adjoint_error("Shape derivative of vertex sum type functional is not implemented!");
 		}
@@ -850,7 +850,7 @@ namespace polyfem::solver
 		if (!j.depend_on_u() && !j.depend_on_gradu() && !j.depend_on_gradu_local())
 			return;
 
-		if (spatial_integral_type == SpatialIntegralType::volume)
+		if (spatial_integral_type == SpatialIntegralType::Volume)
 		{
 			auto storage = utils::create_thread_storage(LocalThreadVecStorage(term.size()));
 			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
@@ -929,7 +929,7 @@ namespace polyfem::solver
 			for (const LocalThreadVecStorage &local_storage : storage)
 				term += local_storage.vec;
 		}
-		else if (spatial_integral_type == SpatialIntegralType::surface)
+		else if (spatial_integral_type == SpatialIntegralType::Surface)
 		{
 			auto storage = utils::create_thread_storage(LocalThreadVecStorage(term.size()));
 			utils::maybe_parallel_for(state.total_local_boundary.size(), [&](int start, int end, int thread_id) {
@@ -1038,7 +1038,7 @@ namespace polyfem::solver
 			for (const LocalThreadVecStorage &local_storage : storage)
 				term += local_storage.vec;
 		}
-		else if (spatial_integral_type == SpatialIntegralType::vertex_sum)
+		else if (spatial_integral_type == SpatialIntegralType::VertexSum)
 		{
 			std::vector<bool> traversed(state.n_bases, false);
 			IntegrableFunctional::ParameterType params;

--- a/src/polyfem/solver/AdjointTools.cpp
+++ b/src/polyfem/solver/AdjointTools.cpp
@@ -173,51 +173,6 @@ namespace polyfem::solver
 		}
 	} // namespace
 
-	void AdjointTools::dJ_macro_strain_adjoint_term(
-		const State &state,
-		const Eigen::MatrixXd &sol,
-		const Eigen::MatrixXd &adjoint,
-		Eigen::VectorXd &one_form)
-	{
-		// doesn't support transient simulation
-		const double t = 0;
-
-		const int dim = state.mesh->dimension();
-		const auto &bases = state.bases;
-		const auto &gbases = state.geom_bases();
-
-		one_form.setZero(dim * dim);
-		auto storage = utils::create_thread_storage(LocalThreadVecStorage(one_form.size()));
-		utils::maybe_parallel_for(bases.size(), [&](int start, int end, int thread_id) {
-			LocalThreadVecStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
-			Eigen::MatrixXd stiffnesses;
-			Eigen::MatrixXd p, grad_p;
-			for (int e = start; e < end; ++e)
-			{
-				assembler::ElementAssemblyValues &vals = local_storage.vals;
-				state.ass_vals_cache.compute(e, dim == 3, bases[e], gbases[e], vals);
-
-				const quadrature::Quadrature &quadrature = vals.quadrature;
-				local_storage.da = vals.det.array() * quadrature.weights.array();
-
-				state.assembler->compute_stiffness_value(t, vals, quadrature.points, sol, stiffnesses);
-				stiffnesses.array().colwise() *= local_storage.da.array();
-
-				io::Evaluator::interpolate_at_local_vals(e, dim, dim, vals, adjoint, p, grad_p);
-
-				for (int a = 0; a < dim; a++)
-					for (int b = 0; b < dim; b++)
-					{
-						int X = a * dim + b;
-						local_storage.vec(X) -= dot(stiffnesses.block(0, X * dim * dim, local_storage.da.size(), dim * dim), grad_p);
-					}
-			}
-		});
-
-		for (const LocalThreadVecStorage &local_storage : storage)
-			one_form += local_storage.vec;
-	}
-
 	double AdjointTools::integrate_objective(
 		const State &state,
 		const IntegrableFunctional &j,
@@ -242,12 +197,11 @@ namespace polyfem::solver
 			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
 				LocalThreadScalarStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
 
-				json params = {};
-				params["t"] = dt * cur_step + t0;
-				params["step"] = cur_step;
+				IntegrableFunctional::ParameterType params;
+				params.t = dt * cur_step + t0;
+				params.step = cur_step;
 
 				Eigen::MatrixXd u, grad_u;
-				Eigen::MatrixXd lambda, mu;
 				Eigen::MatrixXd result;
 
 				for (int e = start; e < end; ++e)
@@ -262,10 +216,10 @@ namespace polyfem::solver
 					const quadrature::Quadrature &quadrature = vals.quadrature;
 					local_storage.da = vals.det.array() * quadrature.weights.array();
 
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], quadrature.points, vals.val);
+					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, quadrature.points, vals.val);
 
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
+					params.elem = e;
+					params.body_id = state.mesh->get_body_id(e);
 					j.evaluate(lame_params, quadrature.points, vals.val, u, grad_u, Eigen::MatrixXd::Zero(0, 0) /*Not used*/, vals, params, result);
 
 					local_storage.val += dot(result, local_storage.da);
@@ -280,16 +234,15 @@ namespace polyfem::solver
 			utils::maybe_parallel_for(state.total_local_boundary.size(), [&](int start, int end, int thread_id) {
 				LocalThreadScalarStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
 
-				Eigen::MatrixXd uv, samples, gtmp;
+				Eigen::MatrixXd uv;
 				Eigen::MatrixXd points, normal;
 				Eigen::VectorXd weights;
 
 				Eigen::MatrixXd u, grad_u;
-				Eigen::MatrixXd lambda, mu;
 				Eigen::MatrixXd result;
-				json params = {};
-				params["t"] = dt * cur_step + t0;
-				params["step"] = cur_step;
+				IntegrableFunctional::ParameterType params;
+				params.t = dt * cur_step + t0;
+				params.step = cur_step;
 
 				for (int lb_id = start; lb_id < end; ++lb_id)
 				{
@@ -308,11 +261,11 @@ namespace polyfem::solver
 						vals.compute(e, state.mesh->is_volume(), points, bases[e], gbases[e]);
 						io::Evaluator::interpolate_at_local_vals(e, dim, actual_dim, vals, solution, u, grad_u);
 
-						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], points, vals.val);
+						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, points, vals.val);
 
-						params["elem"] = e;
-						params["body_id"] = state.mesh->get_body_id(e);
-						params["boundary_id"] = state.mesh->get_boundary_id(global_primitive_id);
+						params.elem = e;
+						params.body_id = state.mesh->get_body_id(e);
+						params.boundary_id = state.mesh->get_boundary_id(global_primitive_id);
 						j.evaluate(lame_params, points, vals.val, u, grad_u, normal, vals, params, result);
 
 						local_storage.val += dot(result, weights);
@@ -325,9 +278,9 @@ namespace polyfem::solver
 		else if (spatial_integral_type == SpatialIntegralType::vertex_sum)
 		{
 			std::vector<bool> traversed(state.n_bases, false);
-			json params = {};
-			params["t"] = dt * cur_step + t0;
-			params["step"] = cur_step;
+			IntegrableFunctional::ParameterType params;
+			params.t = dt * cur_step + t0;
+			params.step = cur_step;
 			for (int e = 0; e < bases.size(); e++)
 			{
 				const auto &bs = bases[e];
@@ -339,12 +292,11 @@ namespace polyfem::solver
 					if (traversed[g.index])
 						continue;
 
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node);
+					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node);
 
-					params["node"] = g.index;
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
-					params["boundary_id"] = -1;
+					params.node = g.index;
+					params.elem = e;
+					params.body_id = state.mesh->get_body_id(e);
 					Eigen::MatrixXd val;
 					j.evaluate(lame_params, Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node, solution.block(g.index * dim, 0, dim, 1).transpose(), Eigen::MatrixXd::Zero(1, dim * actual_dim) /*Not used*/, Eigen::MatrixXd::Zero(0, 0) /*Not used*/, assembler::ElementAssemblyValues(), params, val);
 					integral += val(0);
@@ -377,27 +329,16 @@ namespace polyfem::solver
 
 		auto storage = utils::create_thread_storage(LocalThreadVecStorage(term.size()));
 
-		// Eigen::MatrixXd global_positions;
-		// global_positions.setZero(state.n_geom_bases * dim, 1);
-
-		// for (int e = 0; e < gbases.size(); ++e)
-		// {
-		// 	const auto &gbs = gbases[e].bases;
-		// 	const Eigen::MatrixXd pos = gbases[e].nodes();
-		// 	for (int i = 0; i < gbs.size(); ++i)
-		// 		global_positions.block(gbs[i].global()[0].index * dim, 0, dim, 1) = pos.row(i).transpose();
-		// }
-
 		if (spatial_integral_type == SpatialIntegralType::volume)
 		{
 			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
 				LocalThreadVecStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
 
-				Eigen::MatrixXd u, grad_u, j_val, dj_dgradu, dj_dx, lambda, mu;
+				Eigen::MatrixXd u, grad_u, j_val, dj_dgradu, dj_dx;
 
-				json params = {};
-				params["t"] = cur_time_step * dt + t0;
-				params["step"] = cur_time_step;
+				IntegrableFunctional::ParameterType params;
+				params.t = cur_time_step * dt + t0;
+				params.step = cur_time_step;
 
 				for (int e = start; e < end; ++e)
 				{
@@ -414,10 +355,10 @@ namespace polyfem::solver
 					const quadrature::Quadrature &quadrature = vals.quadrature;
 					local_storage.da = vals.det.array() * quadrature.weights.array();
 
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], quadrature.points, vals.val);
+					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, quadrature.points, vals.val);
 
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
+					params.elem = e;
+					params.body_id = state.mesh->get_body_id(e);
 
 					j.evaluate(lame_params, quadrature.points, vals.val, u, grad_u, Eigen::MatrixXd::Zero(0, 0) /*Not used*/, vals, params, j_val);
 
@@ -465,11 +406,11 @@ namespace polyfem::solver
 				Eigen::MatrixXd uv, points, normal;
 				Eigen::VectorXd &weights = local_storage.da;
 
-				Eigen::MatrixXd u, grad_u, x, grad_x, j_val, dj_dgradu, dj_dgradx, dj_dx, lambda, mu;
+				Eigen::MatrixXd u, grad_u, x, grad_x, j_val, dj_dgradu, dj_dgradx, dj_dx;
 
-				json params = {};
-				params["t"] = cur_time_step * dt + t0;
-				params["step"] = cur_time_step;
+				IntegrableFunctional::ParameterType params;
+				params.t = cur_time_step * dt + t0;
+				params.step = cur_time_step;
 
 				for (int lb_id = start; lb_id < end; ++lb_id)
 				{
@@ -494,11 +435,11 @@ namespace polyfem::solver
 
 						const int n_loc_bases_ = int(vals.basis_values.size());
 
-						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], points, vals.val);
+						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, points, vals.val);
 
-						params["elem"] = e;
-						params["body_id"] = state.mesh->get_body_id(e);
-						params["boundary_id"] = state.mesh->get_boundary_id(global_primitive_id);
+						params.elem = e;
+						params.body_id = state.mesh->get_body_id(e);
+						params.boundary_id = state.mesh->get_boundary_id(global_primitive_id);
 
 						j.evaluate(lame_params, points, vals.val, u, grad_u, normal, vals, params, j_val);
 						j_val = j_val.array().colwise() * weights.array();
@@ -559,6 +500,7 @@ namespace polyfem::solver
 
 							// integrate j * div(gbases) over the whole boundary
 							if (j.depend_on_gradu())
+							{
 								for (int q = 0; q < weights.size(); ++q)
 								{
 									if (dim == actual_dim) // Elasticity PDE
@@ -575,6 +517,7 @@ namespace polyfem::solver
 									for (int d = 0; d < dim; d++)
 										local_storage.vec(v.global[0].index * dim + d) += -dot(tau_q, grad_u_q.col(d) * v.grad_t_m.row(q));
 								}
+							}
 
 							if (j.depend_on_gradx())
 							{
@@ -597,68 +540,6 @@ namespace polyfem::solver
 			term += local_storage.vec;
 
 		term = utils::flatten(utils::unflatten(term, dim)(state.primitive_to_node(), Eigen::all));
-	}
-
-	void AdjointTools::compute_macro_strain_derivative_functional_term(
-		const State &state,
-		const Eigen::MatrixXd &solution,
-		const IntegrableFunctional &j,
-		const std::set<int> &interested_ids, // either body id or surface id
-		const SpatialIntegralType spatial_integral_type,
-		Eigen::VectorXd &term,
-		const int cur_time_step)
-	{
-		const auto &gbases = state.geom_bases();
-		const auto &bases = state.bases;
-		const int dim = state.mesh->dimension();
-		const int actual_dim = state.problem->is_scalar() ? 1 : dim;
-
-		const int n_elements = int(bases.size());
-		term.setZero(dim * dim, 1);
-
-		if (!j.depend_on_gradu())
-			return;
-
-		auto storage = utils::create_thread_storage(LocalThreadVecStorage(term.size()));
-
-		if (spatial_integral_type == SpatialIntegralType::volume)
-		{
-			utils::maybe_parallel_for(n_elements, [&](int start, int end, int thread_id) {
-				LocalThreadVecStorage &local_storage = utils::get_local_thread_storage(storage, thread_id);
-
-				Eigen::MatrixXd u, grad_u, dj_du;
-
-				json params = {};
-				params["step"] = cur_time_step;
-
-				for (int e = start; e < end; ++e)
-				{
-					if (interested_ids.size() != 0 && interested_ids.find(state.mesh->get_body_id(e)) == interested_ids.end())
-						continue;
-
-					assembler::ElementAssemblyValues &vals = local_storage.vals;
-					state.ass_vals_cache.compute(e, state.mesh->is_volume(), bases[e], gbases[e], vals);
-					io::Evaluator::interpolate_at_local_vals(e, dim, actual_dim, vals, solution, u, grad_u);
-
-					const quadrature::Quadrature &quadrature = vals.quadrature;
-					local_storage.da = vals.det.array() * quadrature.weights.array();
-
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, 0., quadrature.points, vals.val);
-
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
-
-					j.dj_dgradu(lame_params, quadrature.points, vals.val, u, grad_u, Eigen::MatrixXd::Zero(0, 0) /*Not used*/, vals, params, dj_du);
-
-					local_storage.vec += dj_du.transpose() * local_storage.da;
-				}
-			});
-		}
-		else
-			log_and_throw_adjoint_error("Not implemented!");
-
-		for (const LocalThreadVecStorage &local_storage : storage)
-			term += local_storage.vec;
 	}
 
 	void AdjointTools::dJ_shape_static_adjoint_term(
@@ -979,9 +860,9 @@ namespace polyfem::solver
 				Eigen::MatrixXd lambda, mu;
 				Eigen::MatrixXd dj_du, dj_dgradu, dj_dgradx;
 
-				json params = {};
-				params["t"] = dt * cur_step + t0;
-				params["step"] = cur_step;
+				IntegrableFunctional::ParameterType params;
+				params.t = dt * cur_step + t0;
+				params.step = cur_step;
 
 				for (int e = start; e < end; ++e)
 				{
@@ -994,14 +875,14 @@ namespace polyfem::solver
 					const quadrature::Quadrature &quadrature = vals.quadrature;
 					local_storage.da = vals.det.array() * quadrature.weights.array();
 
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], quadrature.points, vals.val);
+					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, quadrature.points, vals.val);
 
 					const int n_loc_bases_ = int(vals.basis_values.size());
 
 					io::Evaluator::interpolate_at_local_vals(e, dim, actual_dim, vals, solution, u, grad_u);
 
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
+					params.elem = e;
+					params.body_id = state.mesh->get_body_id(e);
 
 					dj_dgradu.resize(0, 0);
 					if (j.depend_on_gradu())
@@ -1061,9 +942,10 @@ namespace polyfem::solver
 				Eigen::MatrixXd u, grad_u;
 				Eigen::MatrixXd lambda, mu;
 				Eigen::MatrixXd dj_du, dj_dgradu, dj_dgradu_local;
-				json params = {};
-				params["t"] = dt * cur_step + t0;
-				params["step"] = cur_step;
+
+				IntegrableFunctional::ParameterType params;
+				params.t = dt * cur_step + t0;
+				params.step = cur_step;
 
 				for (int lb_id = start; lb_id < end; ++lb_id)
 				{
@@ -1082,15 +964,15 @@ namespace polyfem::solver
 						vals.compute(e, state.mesh->is_volume(), points, bases[e], gbases[e]);
 						io::Evaluator::interpolate_at_local_vals(e, dim, actual_dim, vals, solution, u, grad_u);
 
-						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], points, vals.val);
+						const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, points, vals.val);
 
 						// normal = normal * vals.jac_it[0]; // assuming linear geometry
 
 						const int n_loc_bases_ = int(vals.basis_values.size());
 
-						params["elem"] = e;
-						params["body_id"] = state.mesh->get_body_id(e);
-						params["boundary_id"] = state.mesh->get_boundary_id(global_primitive_id);
+						params.elem = e;
+						params.body_id = state.mesh->get_body_id(e);
+						params.boundary_id = state.mesh->get_boundary_id(global_primitive_id);
 
 						dj_dgradu.resize(0, 0);
 						if (j.depend_on_gradu())
@@ -1159,9 +1041,9 @@ namespace polyfem::solver
 		else if (spatial_integral_type == SpatialIntegralType::vertex_sum)
 		{
 			std::vector<bool> traversed(state.n_bases, false);
-			json params = {};
-			params["t"] = dt * cur_step + t0;
-			params["step"] = cur_step;
+			IntegrableFunctional::ParameterType params;
+			params.t = dt * cur_step + t0;
+			params.step = cur_step;
 			for (int e = 0; e < bases.size(); e++)
 			{
 				const auto &bs = bases[e];
@@ -1173,12 +1055,11 @@ namespace polyfem::solver
 					if (traversed[g.index])
 						continue;
 
-					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params["t"], Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node);
+					const Eigen::MatrixXd lame_params = extract_lame_params(state.assembler->parameters(), e, params.t, Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node);
 
-					params["node"] = g.index;
-					params["elem"] = e;
-					params["body_id"] = state.mesh->get_body_id(e);
-					params["boundary_id"] = -1;
+					params.node = g.index;
+					params.elem = e;
+					params.body_id = state.mesh->get_body_id(e);
 					Eigen::MatrixXd val;
 					j.dj_du(lame_params, Eigen::MatrixXd::Zero(1, dim) /*Not used*/, g.node, solution.block(g.index * dim, 0, dim, 1).transpose(), Eigen::MatrixXd::Zero(1, dim * actual_dim) /*Not used*/, Eigen::MatrixXd::Zero(0, 0) /*Not used*/, assembler::ElementAssemblyValues(), params, val);
 					term.block(g.index * actual_dim, 0, actual_dim, 1) += val.transpose();

--- a/src/polyfem/solver/AdjointTools.hpp
+++ b/src/polyfem/solver/AdjointTools.hpp
@@ -51,19 +51,6 @@ namespace polyfem::solver
 			const SpatialIntegralType spatial_integral_type,
 			const int cur_step,
 			Eigen::VectorXd &term);
-		static void dJ_macro_strain_adjoint_term(
-			const State &state,
-			const Eigen::MatrixXd &sol,
-			const Eigen::MatrixXd &adjoint,
-			Eigen::VectorXd &one_form);
-		static void compute_macro_strain_derivative_functional_term(
-			const State &state,
-			const Eigen::MatrixXd &solution,
-			const IntegrableFunctional &j,
-			const std::set<int> &interested_ids, // either body id or surface id
-			const SpatialIntegralType spatial_integral_type,
-			Eigen::VectorXd &term,
-			const int cur_time_step);
 		static void compute_shape_derivative_functional_term(
 			const State &state,
 			const Eigen::MatrixXd &solution,

--- a/src/polyfem/solver/AdjointTools.hpp
+++ b/src/polyfem/solver/AdjointTools.hpp
@@ -14,9 +14,9 @@ namespace polyfem::solver
 	enum class ParameterType
 	{
 		Shape,
-		Material,
-		FrictionCoeff,
-		DampingCoeff,
+		LameParameter,
+		FrictionCoefficient,
+		DampingCoefficient,
 		InitialCondition,
 		DirichletBC,
 		MacroStrain
@@ -24,26 +24,21 @@ namespace polyfem::solver
 
 	enum class SpatialIntegralType
 	{
-		volume,
-		surface,
-		vertex_sum
+		Volume,
+		Surface,
+		VertexSum
 	};
 
-	class AdjointTools
+	namespace AdjointTools
 	{
-	public:
-		AdjointTools()
-		{
-		}
-
-		static double integrate_objective(
+		double integrate_objective(
 			const State &state,
 			const IntegrableFunctional &j,
 			const Eigen::MatrixXd &solution,
 			const std::set<int> &interested_ids, // either body id or surface id
 			const SpatialIntegralType spatial_integral_type,
 			const int cur_step = 0);
-		static void dJ_du_step(
+		void dJ_du_step(
 			const State &state,
 			const IntegrableFunctional &j,
 			const Eigen::MatrixXd &solution,
@@ -51,7 +46,7 @@ namespace polyfem::solver
 			const SpatialIntegralType spatial_integral_type,
 			const int cur_step,
 			Eigen::VectorXd &term);
-		static void compute_shape_derivative_functional_term(
+		void compute_shape_derivative_functional_term(
 			const State &state,
 			const Eigen::MatrixXd &solution,
 			const IntegrableFunctional &j,
@@ -59,62 +54,62 @@ namespace polyfem::solver
 			const SpatialIntegralType spatial_integral_type,
 			Eigen::VectorXd &term,
 			const int cur_time_step);
-		static void dJ_shape_static_adjoint_term(
+		void dJ_shape_static_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &sol,
 			const Eigen::MatrixXd &adjoint,
 			Eigen::VectorXd &one_form);
-		static void dJ_shape_transient_adjoint_term(
+		void dJ_shape_transient_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
-		static void dJ_material_static_adjoint_term(
+		void dJ_material_static_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &sol,
 			const Eigen::MatrixXd &adjoint,
 			Eigen::VectorXd &one_form);
-		static void dJ_material_transient_adjoint_term(
+		void dJ_material_transient_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
-		static void dJ_friction_transient_adjoint_term(
+		void dJ_friction_transient_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
-		static void dJ_damping_transient_adjoint_term(
+		void dJ_damping_transient_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
-		static void dJ_initial_condition_adjoint_term(
+		void dJ_initial_condition_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
-		static void dJ_dirichlet_transient_adjoint_term(
+		void dJ_dirichlet_transient_adjoint_term(
 			const State &state,
 			const Eigen::MatrixXd &adjoint_nu,
 			const Eigen::MatrixXd &adjoint_p,
 			Eigen::VectorXd &one_form);
 
-		static Eigen::VectorXd map_primitive_to_node_order(
+		Eigen::VectorXd map_primitive_to_node_order(
 			const State &state,
 			const Eigen::VectorXd &primitives);
-		static Eigen::VectorXd map_node_to_primitive_order(
+		Eigen::VectorXd map_node_to_primitive_order(
 			const State &state,
 			const Eigen::VectorXd &nodes);
 
-		static Eigen::MatrixXd edge_normal_gradient(
+		Eigen::MatrixXd edge_normal_gradient(
 			const Eigen::MatrixXd &V);
-		static Eigen::MatrixXd face_normal_gradient(
+		Eigen::MatrixXd face_normal_gradient(
 			const Eigen::MatrixXd &V);
 
-		static Eigen::MatrixXd edge_velocity_divergence(
+		Eigen::MatrixXd edge_velocity_divergence(
 			const Eigen::MatrixXd &V);
-		static Eigen::MatrixXd face_velocity_divergence(
+		Eigen::MatrixXd face_velocity_divergence(
 			const Eigen::MatrixXd &V);
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/Optimizations.cpp
+++ b/src/polyfem/solver/Optimizations.cpp
@@ -95,6 +95,8 @@ namespace polyfem::solver
 			if (type == "transient_integral")
 			{
 				std::shared_ptr<StaticForm> static_obj = std::dynamic_pointer_cast<StaticForm>(create_form(args["static_objective"], var2sim, states));
+				if (!static_obj)
+					log_and_throw_adjoint_error("Transient integral objective must have a static objective!");
 				const auto &state = states[args["state"]];
 				obj = std::make_shared<TransientForm>(var2sim, state->args["time"]["time_steps"], state->args["time"]["dt"], args["integral_type"], args["steps"].get<std::vector<int>>(), static_obj);
 			}
@@ -571,14 +573,9 @@ namespace polyfem::solver
 
 				return node_ids.size() * states[state_id]->mesh->dimension();
 			}
-			else
-			{
-				log_and_throw_adjoint_error("Incorrect specification for parameters.");
-			}
 		}
-		else
-			log_and_throw_adjoint_error("Incorrect specification for parameters.");
-
+		
+		log_and_throw_adjoint_error("Incorrect specification for parameters.");
 		return -1;
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/Optimizations.cpp
+++ b/src/polyfem/solver/Optimizations.cpp
@@ -319,9 +319,7 @@ namespace polyfem::solver
 		else if (composite_map_type == "boundary_excluding_surface")
 		{
 			assert(type == "shape");
-			std::vector<int> excluded_surfaces;
-			for (const auto &s : args["surface_selection"])
-				excluded_surfaces.push_back(s);
+			const std::vector<int> excluded_surfaces = args["surface_selection"];
 			VariableToBoundaryNodesExclusive variable_to_node(*cur_states[0], excluded_surfaces);
 			output_indexing = variable_to_node.get_output_indexing();
 		}
@@ -358,7 +356,7 @@ namespace polyfem::solver
 		int var = 0;
 		for (const auto &arg : args)
 		{
-			const auto& arg_initial = arg["initial"];
+			const auto &arg_initial = arg["initial"];
 			Eigen::VectorXd tmp(variable_sizes[var]);
 			if (arg_initial.is_array() && arg_initial.size() > 0)
 			{
@@ -389,15 +387,13 @@ namespace polyfem::solver
 		in_args["solver"]["max_threads"] = max_threads;
 		if (!args.contains("output") || !args["output"].contains("log") || !args["output"]["log"].contains("level"))
 		{
-			auto tmp = R"({
+			const json tmp = R"({
 					"output": {
 						"log": {
-							"level": -1
+							"level": "error"
 						}
 					}
 				})"_json;
-
-			tmp["output"]["log"]["level"] = "error";
 
 			in_args.merge_patch(tmp);
 		}
@@ -574,7 +570,7 @@ namespace polyfem::solver
 				return node_ids.size() * states[state_id]->mesh->dimension();
 			}
 		}
-		
+
 		log_and_throw_adjoint_error("Incorrect specification for parameters.");
 		return -1;
 	}

--- a/src/polyfem/solver/Optimizations.cpp
+++ b/src/polyfem/solver/Optimizations.cpp
@@ -78,7 +78,7 @@ namespace polyfem::solver
 		log_and_throw_adjoint_error("Invalid nonlinear solver name!");
 	}
 
-	std::shared_ptr<AdjointForm> AdjointOptUtils::create_form(const json &args, const std::vector<std::unique_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states)
+	std::shared_ptr<AdjointForm> AdjointOptUtils::create_form(const json &args, const VariableToSimulationGroup &var2sim, const std::vector<std::shared_ptr<State>> &states)
 	{
 		std::shared_ptr<AdjointForm> obj;
 		if (args.is_array())
@@ -197,7 +197,7 @@ namespace polyfem::solver
 				std::vector<std::shared_ptr<Parametrization>> map_list;
 				for (const auto &arg : args["parametrization"])
 					map_list.push_back(create_parametrization(arg, states, {}));
-				CompositeParametrization composite_map = CompositeParametrization(map_list);
+				CompositeParametrization composite_map(std::move(map_list));
 
 				obj = std::make_shared<ParametrizedProductForm>(composite_map);
 			}
@@ -296,7 +296,6 @@ namespace polyfem::solver
 		std::vector<std::shared_ptr<Parametrization>> map_list;
 		for (const auto &arg : args["composition"])
 			map_list.push_back(create_parametrization(arg, states, variable_sizes));
-		CompositeParametrization composite_map;
 
 		std::vector<std::shared_ptr<State>> cur_states;
 		if (args["state"].is_array())
@@ -305,7 +304,7 @@ namespace polyfem::solver
 		else
 			cur_states.push_back(states[args["state"]]);
 
-		composite_map = CompositeParametrization(map_list);
+		CompositeParametrization composite_map(std::move(map_list));
 
 		const std::string composite_map_type = args["composite_map_type"];
 		Eigen::VectorXi output_indexing;
@@ -376,7 +375,7 @@ namespace polyfem::solver
 		return var2sim;
 	}
 
-	Eigen::VectorXd AdjointOptUtils::inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::unique_ptr<VariableToSimulation>> &var2sim)
+	Eigen::VectorXd AdjointOptUtils::inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, VariableToSimulationGroup &var2sim)
 	{
 		Eigen::VectorXd x;
 		x.setZero(ndof);

--- a/src/polyfem/solver/Optimizations.cpp
+++ b/src/polyfem/solver/Optimizations.cpp
@@ -78,7 +78,7 @@ namespace polyfem::solver
 		log_and_throw_adjoint_error("Invalid nonlinear solver name!");
 	}
 
-	std::shared_ptr<AdjointForm> AdjointOptUtils::create_form(const json &args, const std::vector<std::shared_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states)
+	std::shared_ptr<AdjointForm> AdjointOptUtils::create_form(const json &args, const std::vector<std::unique_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states)
 	{
 		std::shared_ptr<AdjointForm> obj;
 		if (args.is_array())
@@ -288,9 +288,9 @@ namespace polyfem::solver
 		return map;
 	}
 
-	std::shared_ptr<VariableToSimulation> AdjointOptUtils::create_variable_to_simulation(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes)
+	std::unique_ptr<VariableToSimulation> AdjointOptUtils::create_variable_to_simulation(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes)
 	{
-		std::shared_ptr<VariableToSimulation> var2sim;
+		std::unique_ptr<VariableToSimulation> var2sim;
 		const std::string type = args["type"];
 
 		std::vector<std::shared_ptr<Parametrization>> map_list;
@@ -349,34 +349,34 @@ namespace polyfem::solver
 
 		if (type == "shape")
 		{
-			var2sim = std::make_shared<ShapeVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<ShapeVariableToSimulation>(cur_states, composite_map);
 			var2sim->set_output_indexing(output_indexing);
 		}
 		else if (type == "elastic")
 		{
-			var2sim = std::make_shared<ElasticVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<ElasticVariableToSimulation>(cur_states, composite_map);
 		}
 		else if (type == "friction")
 		{
-			var2sim = std::make_shared<FrictionCoeffientVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<FrictionCoeffientVariableToSimulation>(cur_states, composite_map);
 		}
 		else if (type == "damping")
 		{
-			var2sim = std::make_shared<DampingCoeffientVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<DampingCoeffientVariableToSimulation>(cur_states, composite_map);
 		}
 		else if (type == "initial")
 		{
-			var2sim = std::make_shared<InitialConditionVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<InitialConditionVariableToSimulation>(cur_states, composite_map);
 		}
 		else if (type == "dirichlet")
 		{
-			var2sim = std::make_shared<DirichletVariableToSimulation>(cur_states, composite_map);
+			var2sim = std::make_unique<DirichletVariableToSimulation>(cur_states, composite_map);
 		}
 
 		return var2sim;
 	}
 
-	Eigen::VectorXd AdjointOptUtils::inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::shared_ptr<VariableToSimulation>> &var2sim)
+	Eigen::VectorXd AdjointOptUtils::inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::unique_ptr<VariableToSimulation>> &var2sim)
 	{
 		Eigen::VectorXd x;
 		x.setZero(ndof);

--- a/src/polyfem/solver/Optimizations.hpp
+++ b/src/polyfem/solver/Optimizations.hpp
@@ -31,15 +31,15 @@ namespace polyfem::solver
 
 		static std::vector<std::shared_ptr<State>> create_states(const json &state_args, const CacheLevel &level, const size_t max_threads);
 
-		static Eigen::VectorXd inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::shared_ptr<VariableToSimulation>> &var2sim);
+		static Eigen::VectorXd inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::unique_ptr<VariableToSimulation>> &var2sim);
 
 		static void solve_pde(State &state);
 
-		static std::shared_ptr<AdjointForm> create_form(const json &args, const std::vector<std::shared_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states);
+		static std::shared_ptr<AdjointForm> create_form(const json &args, const std::vector<std::unique_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states);
 
 		static std::shared_ptr<Parametrization> create_parametrization(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes);
 
-		static std::shared_ptr<VariableToSimulation> create_variable_to_simulation(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes);
+		static std::unique_ptr<VariableToSimulation> create_variable_to_simulation(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes);
 
 		static int compute_variable_size(const json &args, const std::vector<std::shared_ptr<State>> &states);
 	};

--- a/src/polyfem/solver/Optimizations.hpp
+++ b/src/polyfem/solver/Optimizations.hpp
@@ -28,7 +28,7 @@ namespace polyfem::solver
 
 		static std::shared_ptr<polysolve::nonlinear::Solver> make_nl_solver(const json &solver_params, const json &linear_solver_params, const double characteristic_length);
 
-		static std::shared_ptr<State> create_state(const json &args, CacheLevel level = CacheLevel::Derivatives, const size_t max_threads = 32);
+		static std::shared_ptr<State> create_state(const json &args, CacheLevel level, const size_t max_threads);
 
 		static std::vector<std::shared_ptr<State>> create_states(const json &state_args, const CacheLevel &level, const size_t max_threads);
 

--- a/src/polyfem/solver/Optimizations.hpp
+++ b/src/polyfem/solver/Optimizations.hpp
@@ -20,6 +20,7 @@ namespace polyfem::solver
 	class AdjointForm;
 	class Parametrization;
 	class VariableToSimulation;
+	class VariableToSimulationGroup;
 
 	struct AdjointOptUtils
 	{
@@ -31,11 +32,11 @@ namespace polyfem::solver
 
 		static std::vector<std::shared_ptr<State>> create_states(const json &state_args, const CacheLevel &level, const size_t max_threads);
 
-		static Eigen::VectorXd inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, std::vector<std::unique_ptr<VariableToSimulation>> &var2sim);
+		static Eigen::VectorXd inverse_evaluation(const json &args, const int ndof, const std::vector<int> &variable_sizes, VariableToSimulationGroup &var2sim);
 
 		static void solve_pde(State &state);
 
-		static std::shared_ptr<AdjointForm> create_form(const json &args, const std::vector<std::unique_ptr<VariableToSimulation>> &var2sim, const std::vector<std::shared_ptr<State>> &states);
+		static std::shared_ptr<AdjointForm> create_form(const json &args, const VariableToSimulationGroup &var2sim, const std::vector<std::shared_ptr<State>> &states);
 
 		static std::shared_ptr<Parametrization> create_parametrization(const json &args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes);
 

--- a/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
@@ -115,7 +115,7 @@ namespace polyfem::solver
 	class AMIPSForm : public AdjointForm
 	{
 	public:
-		AMIPSForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state)
+		AMIPSForm(const VariableToSimulationGroup& variable_to_simulation, const State &state)
 			: AdjointForm(variable_to_simulation),
 			  state_(state)
 		{

--- a/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
@@ -205,7 +205,7 @@ namespace polyfem::solver
 			return energy;
 		}
 
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
 		{
 			Eigen::VectorXd X = get_updated_mesh_nodes(x);
 
@@ -225,11 +225,7 @@ namespace polyfem::solver
 					continue;
 				gradv += p->apply_parametrization_jacobian(grad, x);
 			}
-		}
-
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override
-		{
-			return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
+			gradv *= weight();
 		}
 
 		bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override

--- a/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AMIPSForm.hpp
@@ -115,7 +115,7 @@ namespace polyfem::solver
 	class AMIPSForm : public AdjointForm
 	{
 	public:
-		AMIPSForm(const std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulation, const State &state)
+		AMIPSForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state)
 			: AdjointForm(variable_to_simulation),
 			  state_(state)
 		{
@@ -216,7 +216,7 @@ namespace polyfem::solver
 			assert(grad.cols() == 1);
 
 			gradv.setZero(x.size());
-			for (auto &p : variable_to_simulations_)
+			for (const auto &p : variable_to_simulations_)
 			{
 				for (const auto &state : p->get_states())
 					if (state.get() != &state_)
@@ -249,7 +249,7 @@ namespace polyfem::solver
 		{
 			Eigen::VectorXd X = X_init;
 
-			for (auto &p : variable_to_simulations_)
+			for (const auto &p : variable_to_simulations_)
 			{
 				for (const auto &state : p->get_states())
 					if (state.get() != &state_)

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
@@ -9,18 +9,24 @@ namespace polyfem::solver
 	double AdjointForm::value(const Eigen::VectorXd &x) const
 	{
 		double val = Form::value(x);
-		if (print_energy_ == 1)
+		if (print_energy_ == PrintStage::ToPrint)
 		{
 			logger().debug("[{}] {}", print_energy_keyword_, val);
-			print_energy_ = 2;
+			print_energy_ = PrintStage::AlreadyPrinted;
 		}
 		return val;
 	}
 
+	void AdjointForm::enable_energy_print(const std::string &print_energy_keyword)
+	{
+		print_energy_keyword_ = print_energy_keyword;
+		print_energy_ = PrintStage::ToPrint;
+	}
+
 	void AdjointForm::solution_changed(const Eigen::VectorXd &new_x)
 	{
-		if (print_energy_ == 2)
-			print_energy_ = 1;
+		if (print_energy_ == PrintStage::AlreadyPrinted)
+			print_energy_ = PrintStage::ToPrint;
 	}
 
 	void AdjointForm::second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
@@ -47,20 +47,17 @@ namespace polyfem::solver
 			return rhs;
 	}
 
-	void AdjointForm::first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void AdjointForm::first_derivative(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
-		gradv.setZero(x.size());
-		for (const auto &param_map : variable_to_simulations_)
-		{
-			auto adjoint_term = param_map->compute_adjoint_term(x);
-			gradv += adjoint_term;
-		}
-
-		gradv /= weight();
-
 		Eigen::VectorXd partial_grad;
 		compute_partial_gradient_unweighted(x, partial_grad);
-		gradv += partial_grad;
+		gradv = variable_to_simulations_.compute_adjoint_term(x) + 
+					partial_grad * weight();
+	}
+
+	void AdjointForm::first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	{
+		log_and_throw_adjoint_error("first_derivative_unweighted cannot be defined for adjoint forms!");
 	}
 
 	void AdjointForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.cpp
@@ -28,9 +28,9 @@ namespace polyfem::solver
 		log_and_throw_adjoint_error("[{}] Second derivatives not implemented", name());
 	}
 
-	Eigen::MatrixXd AdjointForm::compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
+	Eigen::MatrixXd AdjointForm::compute_reduced_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const
 	{
-		Eigen::MatrixXd rhs = compute_adjoint_rhs_unweighted(x, state);
+		Eigen::MatrixXd rhs = compute_adjoint_rhs(x, state);
 		if (!state.problem->is_time_dependent() && !state.lin_solver_cached) // nonlinear static solve only
 		{
 			Eigen::MatrixXd reduced;
@@ -50,9 +50,8 @@ namespace polyfem::solver
 	void AdjointForm::first_derivative(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		Eigen::VectorXd partial_grad;
-		compute_partial_gradient_unweighted(x, partial_grad);
-		gradv = variable_to_simulations_.compute_adjoint_term(x) + 
-					partial_grad * weight();
+		compute_partial_gradient(x, partial_grad);
+		gradv = variable_to_simulations_.compute_adjoint_term(x) + partial_grad;
 	}
 
 	void AdjointForm::first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
@@ -60,14 +59,31 @@ namespace polyfem::solver
 		log_and_throw_adjoint_error("first_derivative_unweighted cannot be defined for adjoint forms!");
 	}
 
-	void AdjointForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void AdjointForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		gradv = Eigen::VectorXd::Zero(x.size());
 	}
 
-	Eigen::MatrixXd AdjointForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
+	Eigen::MatrixXd AdjointForm::compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const
 	{
 		return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
+	}
+
+	void AdjointForm::update_quantities(const double t, const Eigen::VectorXd &x)
+	{
+
+	}
+	void AdjointForm::init_lagging(const Eigen::VectorXd &x)
+	{
+
+	}
+	void AdjointForm::update_lagging(const Eigen::VectorXd &x, const int iter_num)
+	{
+
+	}
+	void AdjointForm::set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC)
+	{
+
 	}
 
 	double StaticForm::value_unweighted(const Eigen::VectorXd &x) const
@@ -75,21 +91,21 @@ namespace polyfem::solver
 		return value_unweighted_step(0, x);
 	}
 
-	void StaticForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void StaticForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
-		compute_partial_gradient_unweighted_step(0, x, gradv);
+		compute_partial_gradient_step(0, x, gradv);
 	}
 
-	Eigen::VectorXd StaticForm::compute_adjoint_rhs_unweighted_step_prev(const int time_step, const Eigen::VectorXd &x, const State &state) const
+	Eigen::VectorXd StaticForm::compute_adjoint_rhs_step_prev(const int time_step, const Eigen::VectorXd &x, const State &state) const
 	{
 		return Eigen::MatrixXd::Zero(state.ndof(), 1);
 	}
 
-	Eigen::MatrixXd StaticForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
+	Eigen::MatrixXd StaticForm::compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const
 	{
 		assert(!depends_on_step_prev());
 		Eigen::MatrixXd term = Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
-		term.col(0) = compute_adjoint_rhs_unweighted_step(0, x, state);
+		term.col(0) = compute_adjoint_rhs_step(0, x, state);
 
 		return term;
 	}
@@ -119,12 +135,12 @@ namespace polyfem::solver
 
 		return max_stress.maxCoeff();
 	}
-	Eigen::VectorXd MaxStressForm::compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const
+	Eigen::VectorXd MaxStressForm::compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const
 	{
 		log_and_throw_adjoint_error("[{}] Not differentiable!", name());
 		return Eigen::VectorXd();
 	}
-	void MaxStressForm::compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void MaxStressForm::compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		log_and_throw_adjoint_error("[{}] Not differentiable!", name());
 	}

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
@@ -25,26 +25,20 @@ namespace polyfem::solver
 
 		const auto &get_variable_to_simulations() const { return variable_to_simulations_; }
 
-		inline virtual Eigen::MatrixXd compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const final
-		{
-			return compute_reduced_adjoint_rhs_unweighted(x, state) * weight();
-		}
-
-		inline virtual void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final
-		{
-			compute_partial_gradient_unweighted(x, gradv);
-			gradv *= weight();
-		}
-
-		virtual Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const;
-		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const;
-		virtual void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const;
+		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const;
+		virtual void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const;
 
 		virtual void first_derivative(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
+		virtual void update_quantities(const double t, const Eigen::VectorXd &x) final override;
+		virtual void init_lagging(const Eigen::VectorXd &x) final override;
+		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) final override;
+		virtual void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) final override;
 
 	protected:
 		virtual void first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
 		virtual void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const final override;
+
+		virtual Eigen::MatrixXd compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const;
 
 		const VariableToSimulationGroup variable_to_simulations_;
 
@@ -60,13 +54,13 @@ namespace polyfem::solver
 
 		virtual std::string name() const override { return "static"; }
 
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const final override;
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
+		Eigen::MatrixXd compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const final override;
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
 		double value_unweighted(const Eigen::VectorXd &x) const final override;
 
-		virtual Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const = 0;
-		virtual Eigen::VectorXd compute_adjoint_rhs_unweighted_step_prev(const int time_step, const Eigen::VectorXd &x, const State &state) const;
-		virtual void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const = 0;
+		virtual Eigen::VectorXd compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const = 0;
+		virtual Eigen::VectorXd compute_adjoint_rhs_step_prev(const int time_step, const Eigen::VectorXd &x, const State &state) const;
+		virtual void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const = 0;
 		virtual double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const = 0;
 		virtual void solution_changed_step(const int time_step, const Eigen::VectorXd &new_x) {}
 		virtual bool depends_on_step_prev() const final { return depends_on_step_prev_; }
@@ -86,9 +80,9 @@ namespace polyfem::solver
 
 		std::string name() const override { return "max_stress"; }
 
-		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
+		Eigen::VectorXd compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
 		double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const override;
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	private:
 		std::set<int> interested_ids_;

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
@@ -12,23 +12,18 @@ namespace polyfem::solver
 		virtual ~AdjointForm() {}
 
 		virtual std::string name() const override { return "adjoint"; }
+		void enable_energy_print(const std::string &print_energy_keyword);
 
 		double value(const Eigen::VectorXd &x) const override;
-
-		void enable_energy_print(const std::string &print_energy_keyword)
-		{
-			print_energy_keyword_ = print_energy_keyword;
-			print_energy_ = 1;
-		}
-
 		virtual void solution_changed(const Eigen::VectorXd &new_x) override;
 
-		const auto &get_variable_to_simulations() const { return variable_to_simulations_; }
+		const VariableToSimulationGroup &get_variable_to_simulations() const { return variable_to_simulations_; }
 
 		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const;
 		virtual void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const;
-
 		virtual void first_derivative(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
+
+		// not used functions from base class
 		virtual void update_quantities(const double t, const Eigen::VectorXd &x) final override;
 		virtual void init_lagging(const Eigen::VectorXd &x) final override;
 		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) final override;
@@ -37,12 +32,18 @@ namespace polyfem::solver
 	protected:
 		virtual void first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
 		virtual void second_derivative_unweighted(const Eigen::VectorXd &x, StiffnessMatrix &hessian) const final override;
-
 		virtual Eigen::MatrixXd compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const;
 
 		const VariableToSimulationGroup variable_to_simulations_;
 
-		mutable int print_energy_ = 0; // 0: don't print, 1: print, 2: already printed on current solution
+		enum class PrintStage
+		{
+			Inactive,
+			AlreadyPrinted,
+			ToPrint
+		};
+
+		mutable PrintStage print_energy_ = PrintStage::Inactive;
 		std::string print_energy_keyword_;
 	};
 

--- a/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/AdjointForm.hpp
@@ -8,7 +8,7 @@ namespace polyfem::solver
 	class AdjointForm : public Form
 	{
 	public:
-		AdjointForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations) : variable_to_simulations_(variable_to_simulations) {}
+		AdjointForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations) : variable_to_simulations_(variable_to_simulations) {}
 		virtual ~AdjointForm() {}
 
 		virtual std::string name() const override { return "adjoint"; }
@@ -45,7 +45,7 @@ namespace polyfem::solver
 	protected:
 		virtual void first_derivative_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
-		std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations_;
+		const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulations_;
 
 		mutable int print_energy_ = 0; // 0: don't print, 1: print, 2: already printed on current solution
 		std::string print_energy_keyword_;
@@ -77,7 +77,7 @@ namespace polyfem::solver
 	class MaxStressForm : public StaticForm
 	{
 	public:
-		MaxStressForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
+		MaxStressForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
 		{
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			interested_ids_ = std::set(tmp_ids.begin(), tmp_ids.end());

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
@@ -26,7 +26,7 @@ namespace polyfem::solver
 		return barrier_potential_(collision_set, collision_mesh_, displaced_surface);
 	}
 
-	void CollisionBarrierForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void CollisionBarrierForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		const Eigen::MatrixXd displaced_surface = collision_mesh_.vertices(utils::unflatten(get_updated_mesh_nodes(x), state_.mesh->dimension()));
 
@@ -44,6 +44,7 @@ namespace polyfem::solver
 				continue;
 			gradv += p->apply_parametrization_jacobian(grad, x);
 		}
+		gradv *= weight();
 	}
 
 	void CollisionBarrierForm::solution_changed(const Eigen::VectorXd &x)
@@ -52,11 +53,6 @@ namespace polyfem::solver
 
 		const Eigen::MatrixXd displaced_surface = collision_mesh_.vertices(utils::unflatten(get_updated_mesh_nodes(x), state_.mesh->dimension()));
 		build_collision_set(displaced_surface);
-	}
-
-	Eigen::MatrixXd CollisionBarrierForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
-	{
-		return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
 	}
 
 	bool CollisionBarrierForm::is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
@@ -149,7 +145,7 @@ namespace polyfem::solver
 		return barrier_potential_(collision_set, collision_mesh_, displaced_surface);
 	}
 
-	void DeformedCollisionBarrierForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void DeformedCollisionBarrierForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		const Eigen::MatrixXd displaced_surface = collision_mesh_.vertices(utils::unflatten(get_updated_mesh_nodes(x), state_.mesh->dimension()));
 
@@ -167,6 +163,7 @@ namespace polyfem::solver
 				continue;
 			gradv += p->apply_parametrization_jacobian(grad, x);
 		}
+		gradv *= weight();
 	}
 
 	void DeformedCollisionBarrierForm::solution_changed(const Eigen::VectorXd &x)
@@ -175,11 +172,6 @@ namespace polyfem::solver
 
 		const Eigen::MatrixXd displaced_surface = collision_mesh_.vertices(utils::unflatten(get_updated_mesh_nodes(x), state_.mesh->dimension()));
 		build_collision_set(displaced_surface);
-	}
-
-	Eigen::MatrixXd DeformedCollisionBarrierForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
-	{
-		return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
 	}
 
 	bool DeformedCollisionBarrierForm::is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
@@ -3,7 +3,7 @@
 
 namespace polyfem::solver
 {
-	CollisionBarrierForm::CollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat)
+	CollisionBarrierForm::CollisionBarrierForm(const VariableToSimulationGroup& variable_to_simulation, const State &state, const double dhat)
 		: AdjointForm(variable_to_simulation), state_(state), dhat_(dhat), barrier_potential_(dhat)
 	{
 		State::build_collision_mesh(
@@ -123,7 +123,7 @@ namespace polyfem::solver
 		return AdjointTools::map_primitive_to_node_order(state_, X);
 	}
 
-	DeformedCollisionBarrierForm::DeformedCollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat)
+	DeformedCollisionBarrierForm::DeformedCollisionBarrierForm(const VariableToSimulationGroup& variable_to_simulation, const State &state, const double dhat)
 		: AdjointForm(variable_to_simulation), state_(state), dhat_(dhat), barrier_potential_(dhat)
 	{
 		if (state_.n_bases != state_.n_geom_bases)

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.cpp
@@ -3,7 +3,7 @@
 
 namespace polyfem::solver
 {
-	CollisionBarrierForm::CollisionBarrierForm(const std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulation, const State &state, const double dhat)
+	CollisionBarrierForm::CollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat)
 		: AdjointForm(variable_to_simulation), state_(state), dhat_(dhat), barrier_potential_(dhat)
 	{
 		State::build_collision_mesh(
@@ -35,7 +35,7 @@ namespace polyfem::solver
 		grad = AdjointTools::map_node_to_primitive_order(state_, grad);
 
 		gradv.setZero(x.size());
-		for (auto &p : variable_to_simulations_)
+		for (const auto &p : variable_to_simulations_)
 		{
 			for (const auto &state : p->get_states())
 				if (state.get() != &state_)
@@ -107,7 +107,7 @@ namespace polyfem::solver
 	{
 		Eigen::VectorXd X = X_init;
 
-		for (auto &p : variable_to_simulations_)
+		for (const auto &p : variable_to_simulations_)
 		{
 			for (const auto &state : p->get_states())
 				if (state.get() != &state_)
@@ -123,7 +123,7 @@ namespace polyfem::solver
 		return AdjointTools::map_primitive_to_node_order(state_, X);
 	}
 
-	DeformedCollisionBarrierForm::DeformedCollisionBarrierForm(const std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulation, const State &state, const double dhat)
+	DeformedCollisionBarrierForm::DeformedCollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat)
 		: AdjointForm(variable_to_simulation), state_(state), dhat_(dhat), barrier_potential_(dhat)
 	{
 		if (state_.n_bases != state_.n_geom_bases)
@@ -158,7 +158,7 @@ namespace polyfem::solver
 		grad = AdjointTools::map_node_to_primitive_order(state_, grad);
 
 		gradv.setZero(x.size());
-		for (auto &p : variable_to_simulations_)
+		for (const auto &p : variable_to_simulations_)
 		{
 			for (const auto &state : p->get_states())
 				if (state.get() != &state_)
@@ -230,7 +230,7 @@ namespace polyfem::solver
 	{
 		Eigen::VectorXd X = X_init;
 
-		for (auto &p : variable_to_simulations_)
+		for (const auto &p : variable_to_simulations_)
 		{
 			for (const auto &state : p->get_states())
 				if (state.get() != &state_)

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
@@ -14,11 +14,9 @@ namespace polyfem::solver
 
 		double value_unweighted(const Eigen::VectorXd &x) const override;
 
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 		void solution_changed(const Eigen::VectorXd &x) override;
-
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;
 
 		bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override;
 
@@ -58,11 +56,9 @@ namespace polyfem::solver
 
 		double value_unweighted(const Eigen::VectorXd &x) const override;
 
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 		void solution_changed(const Eigen::VectorXd &x) override;
-
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;
 
 		bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override;
 

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
@@ -10,7 +10,7 @@ namespace polyfem::solver
 	class CollisionBarrierForm : public AdjointForm
 	{
 	public:
-		CollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat);
+		CollisionBarrierForm(const VariableToSimulationGroup& variable_to_simulation, const State &state, const double dhat);
 
 		double value_unweighted(const Eigen::VectorXd &x) const override;
 
@@ -44,7 +44,7 @@ namespace polyfem::solver
 	// class LayerThicknessForm : public ParametrizationForm
 	// {
 	// public:
-	// 	LayerThicknessForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const CompositeParametrization &parametrizations, const State &state) : ParametrizationForm(variable_to_simulations, parametrizations), state_(state)
+	// 	LayerThicknessForm(const VariableToSimulationGroup &variable_to_simulations, const CompositeParametrization &parametrizations, const State &state) : ParametrizationForm(variable_to_simulations, parametrizations), state_(state)
 	// 	{
 	// 	}
 	// }
@@ -52,7 +52,7 @@ namespace polyfem::solver
 	class DeformedCollisionBarrierForm : public AdjointForm
 	{
 	public:
-		DeformedCollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat);
+		DeformedCollisionBarrierForm(const VariableToSimulationGroup& variable_to_simulation, const State &state, const double dhat);
 
 		std::string name() const override { return "deformed_collision_barrier"; }
 

--- a/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/BarrierForms.hpp
@@ -10,7 +10,7 @@ namespace polyfem::solver
 	class CollisionBarrierForm : public AdjointForm
 	{
 	public:
-		CollisionBarrierForm(const std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulation, const State &state, const double dhat);
+		CollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat);
 
 		double value_unweighted(const Eigen::VectorXd &x) const override;
 
@@ -44,7 +44,7 @@ namespace polyfem::solver
 	// class LayerThicknessForm : public ParametrizationForm
 	// {
 	// public:
-	// 	LayerThicknessForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const CompositeParametrization &parametrizations, const State &state) : ParametrizationForm(variable_to_simulations, parametrizations), state_(state)
+	// 	LayerThicknessForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const CompositeParametrization &parametrizations, const State &state) : ParametrizationForm(variable_to_simulations, parametrizations), state_(state)
 	// 	{
 	// 	}
 	// }
@@ -52,7 +52,7 @@ namespace polyfem::solver
 	class DeformedCollisionBarrierForm : public AdjointForm
 	{
 	public:
-		DeformedCollisionBarrierForm(const std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulation, const State &state, const double dhat);
+		DeformedCollisionBarrierForm(const std::vector<std::unique_ptr<VariableToSimulation>>& variable_to_simulation, const State &state, const double dhat);
 
 		std::string name() const override { return "deformed_collision_barrier"; }
 

--- a/src/polyfem/solver/forms/adjoint_forms/CMakeLists.txt
+++ b/src/polyfem/solver/forms/adjoint_forms/CMakeLists.txt
@@ -7,11 +7,13 @@ set(SOURCES
 	SpatialIntegralForms.hpp
 	VariableToSimulation.cpp
 	VariableToSimulation.hpp
+	CompositeForm.cpp
 	CompositeForm.hpp
 	CompositeForms.cpp
 	CompositeForms.hpp
 	SumCompositeForm.hpp
 	AMIPSForm.hpp
+	WeightedVolumeForm.cpp
 	WeightedVolumeForm.hpp
 	ParametrizedProductForm.hpp
 	TransientForm.hpp

--- a/src/polyfem/solver/forms/adjoint_forms/CompositeForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/CompositeForm.cpp
@@ -1,0 +1,136 @@
+#include "CompositeForm.hpp"
+#include <polyfem/State.hpp>
+
+namespace polyfem::solver
+{
+	Eigen::MatrixXd CompositeForm::compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
+	{
+		Eigen::VectorXd composite_grad = compose_grad(get_inputs(x));
+
+		Eigen::MatrixXd term;
+		Eigen::VectorXd tmp_grad;
+		for (int i = 0; i < forms_.size(); i++)
+		{
+			if (i == 0)
+				term = composite_grad(i) * forms_[i]->compute_adjoint_rhs(x, state);
+			else
+				term += composite_grad(i) * forms_[i]->compute_adjoint_rhs(x, state); // important: not "unweighted"
+		}
+
+		return term;
+	}
+
+	void CompositeForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	{
+		Eigen::VectorXd composite_grad = compose_grad(get_inputs(x));
+
+		gradv.setZero(x.size());
+		Eigen::VectorXd tmp_grad;
+		for (int i = 0; i < forms_.size(); i++)
+		{
+			forms_[i]->compute_partial_gradient(x, tmp_grad); // important: not "unweighted"
+			gradv += composite_grad(i) * tmp_grad;
+		}
+	}
+
+	Eigen::VectorXd CompositeForm::get_inputs(const Eigen::VectorXd &x) const
+	{
+		Eigen::VectorXd values;
+		values.setZero(forms_.size());
+
+		for (int i = 0; i < forms_.size(); i++)
+			values(i) = forms_[i]->value(x);
+
+		return values;
+	}
+
+	double CompositeForm::value_unweighted(const Eigen::VectorXd &x) const
+	{
+		return compose(get_inputs(x));
+	}
+
+	void CompositeForm::init(const Eigen::VectorXd &x)
+	{
+		for (const auto &f : forms_)
+			f->init(x);
+	}
+
+	bool CompositeForm::is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+	{
+		for (const auto &f : forms_)
+		{
+			if (f->enabled() && !f->is_step_valid(x0, x1))
+				return false;
+		}
+		return true;
+	}
+
+	double CompositeForm::max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+	{
+		double step = 1;
+		for (const auto &f : forms_)
+			if (f->enabled())
+				step = std::min(step, f->max_step_size(x0, x1));
+
+		return step;
+	}
+
+	void CompositeForm::line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1)
+	{
+		for (const auto &f : forms_)
+			f->line_search_begin(x0, x1);
+	}
+
+	void CompositeForm::line_search_end()
+	{
+		for (const auto &f : forms_)
+			f->line_search_end();
+	}
+
+	void CompositeForm::post_step(const polysolve::nonlinear::PostStepData &data)
+	{
+		for (const auto &f : forms_)
+			f->post_step(data);
+	}
+
+	void CompositeForm::solution_changed(const Eigen::VectorXd &new_x)
+	{
+		AdjointForm::solution_changed(new_x);
+		for (const auto &f : forms_)
+			f->solution_changed(new_x);
+	}
+
+	void CompositeForm::update_quantities(const double t, const Eigen::VectorXd &x)
+	{
+		for (const auto &f : forms_)
+			f->update_quantities(t, x);
+	}
+
+	void CompositeForm::init_lagging(const Eigen::VectorXd &x)
+	{
+		for (const auto &f : forms_)
+			f->init_lagging(x);
+	}
+
+	void CompositeForm::update_lagging(const Eigen::VectorXd &x, const int iter_num)
+	{
+		for (const auto &f : forms_)
+			f->update_lagging(x, iter_num);
+	}
+
+	void CompositeForm::set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC)
+	{
+		for (const auto &f : forms_)
+			f->set_apply_DBC(x, apply_DBC);
+	}
+
+	bool CompositeForm::is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+	{
+		for (const auto &f : forms_)
+		{
+			if (f->enabled() && !f->is_step_collision_free(x0, x1))
+				return false;
+		}
+		return true;
+	}
+} // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
@@ -8,6 +8,7 @@ namespace polyfem::solver
 {
 	class CompositeForm : public AdjointForm
 	{
+		friend AdjointForm;
 	public:
 		CompositeForm(const VariableToSimulationGroup &variable_to_simulations, const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(variable_to_simulations), forms_(forms) {}
 		CompositeForm(const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(forms[0]->get_variable_to_simulations()), forms_(forms) {}
@@ -15,8 +16,8 @@ namespace polyfem::solver
 
 		virtual int n_objs() const final { return forms_.size(); }
 
-		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override final;
-		virtual void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override final;
+		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const override final;
+		virtual void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override final;
 
 		virtual double compose(const Eigen::VectorXd &inputs) const = 0;
 		virtual Eigen::VectorXd compose_grad(const Eigen::VectorXd &inputs) const = 0;
@@ -31,10 +32,6 @@ namespace polyfem::solver
 		virtual void line_search_end() final override;
 		virtual void post_step(const polysolve::nonlinear::PostStepData &data) final override;
 		virtual void solution_changed(const Eigen::VectorXd &new_x) final override;
-		virtual void update_quantities(const double t, const Eigen::VectorXd &x) final override;
-		virtual void init_lagging(const Eigen::VectorXd &x) final override;
-		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) final override;
-		virtual void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) final override;
 		virtual bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
 
 	private:

--- a/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
@@ -9,145 +9,33 @@ namespace polyfem::solver
 	class CompositeForm : public AdjointForm
 	{
 	public:
-		CompositeForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(variable_to_simulations), forms_(forms) {}
+		CompositeForm(const VariableToSimulationGroup &variable_to_simulations, const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(variable_to_simulations), forms_(forms) {}
 		CompositeForm(const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(forms[0]->get_variable_to_simulations()), forms_(forms) {}
 		virtual ~CompositeForm() {}
 
 		virtual int n_objs() const final { return forms_.size(); }
 
-		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override final
-		{
-			Eigen::VectorXd composite_grad = compose_grad(get_inputs(x));
-
-			Eigen::MatrixXd term;
-			Eigen::VectorXd tmp_grad;
-			for (int i = 0; i < forms_.size(); i++)
-			{
-				if (i == 0)
-					term = composite_grad(i) * forms_[i]->compute_adjoint_rhs(x, state);
-				else
-					term += composite_grad(i) * forms_[i]->compute_adjoint_rhs(x, state); // important: not "unweighted"
-			}
-
-			return term;
-		}
-
-		virtual void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override final
-		{
-			Eigen::VectorXd composite_grad = compose_grad(get_inputs(x));
-
-			gradv.setZero(x.size());
-			Eigen::VectorXd tmp_grad;
-			for (int i = 0; i < forms_.size(); i++)
-			{
-				forms_[i]->compute_partial_gradient(x, tmp_grad); // important: not "unweighted"
-				gradv += composite_grad(i) * tmp_grad;
-			}
-		}
+		virtual Eigen::MatrixXd compute_reduced_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override final;
+		virtual void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override final;
 
 		virtual double compose(const Eigen::VectorXd &inputs) const = 0;
 		virtual Eigen::VectorXd compose_grad(const Eigen::VectorXd &inputs) const = 0;
 
-		Eigen::VectorXd get_inputs(const Eigen::VectorXd &x) const
-		{
-			Eigen::VectorXd values;
-			values.setZero(forms_.size());
+		Eigen::VectorXd get_inputs(const Eigen::VectorXd &x) const;
 
-			for (int i = 0; i < forms_.size(); i++)
-				values(i) = forms_[i]->value(x);
-
-			return values;
-		}
-
-		virtual double value_unweighted(const Eigen::VectorXd &x) const final override
-		{
-			return compose(get_inputs(x));
-		}
-
-		virtual void init(const Eigen::VectorXd &x) override
-		{
-			for (const auto &f : forms_)
-				f->init(x);
-		}
-
-		virtual bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override
-		{
-			for (const auto &f : forms_)
-			{
-				if (f->enabled() && !f->is_step_valid(x0, x1))
-					return false;
-			}
-			return true;
-		}
-
-		virtual double max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override
-		{
-			double step = 1;
-			for (const auto &f : forms_)
-				if (f->enabled())
-					step = std::min(step, f->max_step_size(x0, x1));
-
-			return step;
-		}
-
-		virtual void line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) override
-		{
-			for (const auto &f : forms_)
-				f->line_search_begin(x0, x1);
-		}
-
-		virtual void line_search_end() override
-		{
-			for (const auto &f : forms_)
-				f->line_search_end();
-		}
-
-		virtual void post_step(const polysolve::nonlinear::PostStepData &data) override
-		{
-			for (const auto &f : forms_)
-				f->post_step(data);
-		}
-
-		virtual void solution_changed(const Eigen::VectorXd &new_x) override
-		{
-			AdjointForm::solution_changed(new_x);
-			for (const auto &f : forms_)
-				f->solution_changed(new_x);
-		}
-
-		virtual void update_quantities(const double t, const Eigen::VectorXd &x) override
-		{
-			for (const auto &f : forms_)
-				f->update_quantities(t, x);
-		}
-
-		virtual void init_lagging(const Eigen::VectorXd &x) override
-		{
-			for (const auto &f : forms_)
-				f->init_lagging(x);
-		}
-
-		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) override
-		{
-			for (const auto &f : forms_)
-				f->update_lagging(x, iter_num);
-		}
-
-		virtual void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) override
-		{
-			for (const auto &f : forms_)
-				f->set_apply_DBC(x, apply_DBC);
-		}
-
-		virtual bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override
-		{
-			for (const auto &f : forms_)
-			{
-				if (f->enabled() && !f->is_step_collision_free(x0, x1))
-					return false;
-			}
-			return true;
-		}
+		virtual double value_unweighted(const Eigen::VectorXd &x) const final override;
+		virtual void init(const Eigen::VectorXd &x) final override;
+		virtual bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
+		virtual double max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
+		virtual void line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) final override;
+		virtual void line_search_end() final override;
+		virtual void post_step(const polysolve::nonlinear::PostStepData &data) final override;
+		virtual void solution_changed(const Eigen::VectorXd &new_x) final override;
+		virtual void update_quantities(const double t, const Eigen::VectorXd &x) final override;
+		virtual void init_lagging(const Eigen::VectorXd &x) final override;
+		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) final override;
+		virtual void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) final override;
+		virtual bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
 
 	private:
 		std::vector<std::shared_ptr<AdjointForm>> forms_;

--- a/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/CompositeForm.hpp
@@ -9,7 +9,7 @@ namespace polyfem::solver
 	class CompositeForm : public AdjointForm
 	{
 	public:
-		CompositeForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(variable_to_simulations), forms_(forms) {}
+		CompositeForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(variable_to_simulations), forms_(forms) {}
 		CompositeForm(const std::vector<std::shared_ptr<AdjointForm>> &forms) : AdjointForm(forms[0]->get_variable_to_simulations()), forms_(forms) {}
 		virtual ~CompositeForm() {}
 

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.cpp
@@ -3,8 +3,59 @@
 
 namespace polyfem::solver
 {
-    Eigen::MatrixXd ParametrizationForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
-    { 
-        return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size()); 
+    void ParametrizationForm::init(const Eigen::VectorXd &x)
+    {
+        init_with_param(apply_parametrizations(x));
+    }
+
+    bool ParametrizationForm::is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+    {
+        return is_step_valid_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
+    }
+
+    double ParametrizationForm::max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+    {
+        return max_step_size_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
+    }
+
+    void ParametrizationForm::line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1)
+    {
+        line_search_begin_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
+    }
+
+    void ParametrizationForm::line_search_end()
+    {
+        line_search_end_with_param();
+    }
+
+    void ParametrizationForm::post_step(const polysolve::nonlinear::PostStepData &data)
+    {
+        post_step_with_param(polysolve::nonlinear::PostStepData(
+            data.iter_num,
+            data.solver_info,
+            apply_parametrizations(data.x),
+            parametrizations_.apply_jacobian(data.grad, data.x)));
+    }
+
+    double ParametrizationForm::value_unweighted(const Eigen::VectorXd &x) const
+    {
+        Eigen::VectorXd y = apply_parametrizations(x);
+        return value_unweighted_with_param(y);
+    }
+
+    void ParametrizationForm::solution_changed(const Eigen::VectorXd &new_x)
+    {
+        solution_changed_with_param(apply_parametrizations(new_x));
+    }
+
+    void ParametrizationForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+    {
+        compute_partial_gradient_with_param(apply_parametrizations(x), gradv);
+        gradv = parametrizations_.apply_jacobian(gradv, x);
+    }
+
+    bool ParametrizationForm::is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
+    {
+        return is_step_collision_free_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
     }
 }

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.hpp
@@ -17,77 +17,19 @@ namespace polyfem::solver
 		ParametrizationForm(const CompositeParametrization &parametrizations) : AdjointForm({}), parametrizations_(parametrizations) {}
 		virtual ~ParametrizationForm() {}
 
-		virtual void init(const Eigen::VectorXd &x) final override
-		{
-			init_with_param(apply_parametrizations(x));
-		}
-
-		virtual bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override
-		{
-			return is_step_valid_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
-		}
-
-		virtual double max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final
-		{
-			return max_step_size_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
-		}
-
-		virtual void line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) final override
-		{
-			line_search_begin_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
-		}
-
-		virtual void line_search_end() final override
-		{
-			line_search_end_with_param();
-		}
-
-		virtual void post_step(const polysolve::nonlinear::PostStepData &data) final override
-		{
-			post_step_with_param(polysolve::nonlinear::PostStepData(
-				data.iter_num,
-				data.solver_info,
-				apply_parametrizations(data.x),
-				parametrizations_.apply_jacobian(data.grad, data.x)));
-		}
-
-		virtual void solution_changed(const Eigen::VectorXd &new_x) final override
-		{
-			solution_changed_with_param(apply_parametrizations(new_x));
-		}
-
-		virtual void update_quantities(const double t, const Eigen::VectorXd &x) final override
-		{
-			update_quantities_with_param(t, apply_parametrizations(x));
-		}
-
-		virtual void init_lagging(const Eigen::VectorXd &x) final override
-		{
-			init_lagging_with_param(apply_parametrizations(x));
-		}
-
-		virtual void update_lagging(const Eigen::VectorXd &x, const int iter_num) final override
-		{
-			update_lagging_with_param(apply_parametrizations(x), iter_num);
-		}
-
-		virtual void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) final override
-		{
-			set_apply_DBC_with_param(apply_parametrizations(x), apply_DBC);
-		}
-
-		virtual bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override
-		{
-			return is_step_collision_free_with_param(apply_parametrizations(x0), apply_parametrizations(x1));
-		}
+		virtual void init(const Eigen::VectorXd &x) final override;
+		virtual bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
+		virtual double max_step_size(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final;
+		virtual void line_search_begin(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) final override;
+		virtual void line_search_end() final override;
+		virtual void post_step(const polysolve::nonlinear::PostStepData &data) final override;
+		virtual void solution_changed(const Eigen::VectorXd &new_x) final override;
+		virtual bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const final override;
 
 	protected:
-		virtual double value_unweighted(const Eigen::VectorXd &x) const final override
-		{
-			Eigen::VectorXd y = apply_parametrizations(x);
-			return value_unweighted_with_param(y);
-		}
-
+		virtual double value_unweighted(const Eigen::VectorXd &x) const final override;
+		virtual void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override;
+		
 		virtual void init_with_param(const Eigen::VectorXd &x) {}
 		virtual bool is_step_valid_with_param(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const { return true; }
 		virtual double max_step_size_with_param(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const { return 1; }
@@ -95,28 +37,14 @@ namespace polyfem::solver
 		virtual void line_search_end_with_param() {}
 		virtual void post_step_with_param(const polysolve::nonlinear::PostStepData &data) {}
 		virtual void solution_changed_with_param(const Eigen::VectorXd &new_x) {}
-		virtual void update_quantities_with_param(const double t, const Eigen::VectorXd &x) {}
-		virtual void init_lagging_with_param(const Eigen::VectorXd &x) {}
-		virtual void update_lagging_with_param(const Eigen::VectorXd &x, const int iter_num) {}
-		virtual void set_apply_DBC_with_param(const Eigen::VectorXd &x, bool apply_DBC) {}
 		virtual bool is_step_collision_free_with_param(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const { return true; }
 		virtual double value_unweighted_with_param(const Eigen::VectorXd &x) const { return 0; }
-
-	protected:
-		virtual void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const final override
-		{
-			compute_partial_gradient_unweighted_with_param(apply_parametrizations(x), gradv);
-			gradv = parametrizations_.apply_jacobian(gradv, x);
-		}
-
-		virtual Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const final override;
-
-		virtual void compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const = 0;
+		virtual void compute_partial_gradient_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const = 0;
 
 	private:
 		CompositeParametrization parametrizations_;
 
-		Eigen::VectorXd apply_parametrizations(const Eigen::VectorXd &x) const
+		inline Eigen::VectorXd apply_parametrizations(const Eigen::VectorXd &x) const
 		{
 			return parametrizations_.eval(x);
 		}

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizationForm.hpp
@@ -14,7 +14,7 @@ namespace polyfem::solver
 	class ParametrizationForm : public AdjointForm
 	{
 	public:
-		ParametrizationForm(const CompositeParametrization &parametrizations) : AdjointForm({}), parametrizations_(parametrizations) {}
+		ParametrizationForm(CompositeParametrization &&parametrizations) : AdjointForm({}), parametrizations_(parametrizations) {}
 		virtual ~ParametrizationForm() {}
 
 		virtual void init(const Eigen::VectorXd &x) final override;

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
@@ -19,7 +19,7 @@ namespace polyfem::solver
 			return x.prod();
 		}
 
-		inline void compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
+		inline void compute_partial_gradient_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
 		{
 			gradv.setOnes(x.size());
 			for (int i = 0; i < x.size(); i++)

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
@@ -13,12 +13,13 @@ namespace polyfem::solver
 		{
 		}
 
+	protected:
 		inline double value_unweighted_with_param(const Eigen::VectorXd &x) const override
 		{
 			return x.prod();
 		}
 
-		inline void first_derivative_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
+		inline void compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
 		{
 			gradv.setOnes(x.size());
 			for (int i = 0; i < x.size(); i++)
@@ -29,6 +30,7 @@ namespace polyfem::solver
 						gradv(i) *= x(j);
 				}
 			}
+			gradv *= weight();
 		}
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/ParametrizedProductForm.hpp
@@ -9,7 +9,7 @@ namespace polyfem::solver
 	class ParametrizedProductForm : public ParametrizationForm
 	{
 	public:
-		ParametrizedProductForm(const CompositeParametrization &parametrizations) : ParametrizationForm(parametrizations)
+		ParametrizedProductForm(CompositeParametrization &&parametrizations) : ParametrizationForm(std::move(parametrizations))
 		{
 		}
 

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
@@ -160,7 +160,7 @@ namespace polyfem::solver
 		}
 
 		gradv.setZero(x.size());
-		for (auto &p : variable_to_simulations_)
+		for (const auto &p : variable_to_simulations_)
 		{
 			for (const auto &state : p->get_states())
 				if (state.get() != &state_)

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
@@ -154,16 +154,8 @@ namespace polyfem::solver
 			grad = utils::flatten(2 * (L.transpose() * (L * V)));
 		}
 
-		gradv.setZero(x.size());
-		for (const auto &p : variable_to_simulations_)
-		{
-			for (const auto &state : p->get_states())
-				if (state.get() != &state_)
-					continue;
-			if (p->get_parameter_type() != ParameterType::Shape)
-				continue;
-			gradv += p->apply_parametrization_jacobian(grad, x);
-		}
-		gradv *= weight();
+		gradv = weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::Shape, &state_, x, [&grad]() {
+			return grad;
+		});
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.cpp
@@ -4,11 +4,6 @@
 
 namespace polyfem::solver
 {
-	Eigen::MatrixXd BoundarySmoothingForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
-	{
-		return Eigen::MatrixXd::Zero(state.ndof(), state.diff_cached.size());
-	}
-
 	void BoundarySmoothingForm::init_form()
 	{
 		const auto &mesh = *(state_.mesh);
@@ -114,7 +109,7 @@ namespace polyfem::solver
 		return val;
 	}
 
-	void BoundarySmoothingForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void BoundarySmoothingForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		const auto &mesh = *(state_.mesh);
 		const int dim = mesh.dimension();
@@ -169,5 +164,6 @@ namespace polyfem::solver
 				continue;
 			gradv += p->apply_parametrization_jacobian(grad, x);
 		}
+		gradv *= weight();
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
@@ -12,7 +12,7 @@ namespace polyfem::solver
 	class BoundarySmoothingForm : public AdjointForm
 	{
 	public:
-		BoundarySmoothingForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const bool scale_invariant, const int power) : AdjointForm(variable_to_simulations),
+		BoundarySmoothingForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const bool scale_invariant, const int power) : AdjointForm(variable_to_simulations),
 																																													state_(state),
 																																													scale_invariant_(scale_invariant),
 																																													power_(power) { init_form(); }

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
@@ -12,7 +12,7 @@ namespace polyfem::solver
 	class BoundarySmoothingForm : public AdjointForm
 	{
 	public:
-		BoundarySmoothingForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const bool scale_invariant, const int power) : AdjointForm(variable_to_simulations),
+		BoundarySmoothingForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const bool scale_invariant, const int power) : AdjointForm(variable_to_simulations),
 																																													state_(state),
 																																													scale_invariant_(scale_invariant),
 																																													power_(power) { init_form(); }

--- a/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SmoothingForms.hpp
@@ -18,8 +18,7 @@ namespace polyfem::solver
 																																													power_(power) { init_form(); }
 
 		double value_unweighted(const Eigen::VectorXd &x) const override;
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	private:
 		void init_form();

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.cpp
@@ -392,7 +392,7 @@ namespace polyfem::solver
 		j.set_dj_dgradu([formulation, dimensions, this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 			val.setZero(grad_u.rows(), grad_u.cols());
 
-			const int dim = sqrt(grad_u.cols());
+			const int dim = state_.mesh->dimension();
 			Eigen::MatrixXd grad_u_q, stiffness, stress;
 			for (int q = 0; q < grad_u.rows(); q++)
 			{

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.cpp
@@ -136,7 +136,7 @@ namespace polyfem::solver
 	void ElasticEnergyForm::compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		SpatialIntegralForm::compute_partial_gradient_step(time_step, x, gradv);
-		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::Material, &state_, x, [this]() {
+		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::LameParameter, &state_, x, [this]() {
 			log_and_throw_adjoint_error("[{}] Doesn't support derivatives wrt. material!", name());
 			return Eigen::VectorXd::Zero(0).eval();
 		});
@@ -201,7 +201,7 @@ namespace polyfem::solver
 	void StressNormForm::compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		SpatialIntegralForm::compute_partial_gradient_step(time_step, x, gradv);
-		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::Material, &state_, x, [this]() {
+		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::LameParameter, &state_, x, [this]() {
 			log_and_throw_adjoint_error("[{}] Doesn't support derivatives wrt. material!", name());
 			return Eigen::VectorXd::Zero(0).eval();
 		});
@@ -253,7 +253,7 @@ namespace polyfem::solver
 		const double t = state_.problem->is_time_dependent() ? dt * time_step + state_.args["time"]["t0"].get<double>() : 0;
 
 		SpatialIntegralForm::compute_partial_gradient_step(time_step, x, gradv);
-		gradv = weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::Material, &state_, x, [this, t, dt, time_step, &x]() {
+		gradv = weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::LameParameter, &state_, x, [this, t, dt, time_step, &x]() {
 			const auto &bases = state_.bases;
 			Eigen::VectorXd term = Eigen::VectorXd::Zero(bases.size() * 2);
 			const int dim = state_.mesh->dimension();
@@ -359,7 +359,7 @@ namespace polyfem::solver
 	void StressForm::compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		SpatialIntegralForm::compute_partial_gradient_step(time_step, x, gradv);
-		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::Material, &state_, x, [this]() {
+		gradv += weight() * variable_to_simulations_.apply_parametrization_jacobian(ParameterType::LameParameter, &state_, x, [this]() {
 			log_and_throw_adjoint_error("[{}] Doesn't support derivatives wrt. material!", name());
 			return Eigen::VectorXd::Zero(0).eval();
 		});

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
@@ -17,9 +17,9 @@ namespace polyfem::solver
 
 		void set_integral_type(const SpatialIntegralType type) { spatial_integral_type_ = type; }
 
-		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
+		Eigen::VectorXd compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
 		double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const override;
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		virtual IntegrableFunctional get_integral_functional() const = 0;
@@ -42,7 +42,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "elastic_energy"; }
 
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		IntegrableFunctional get_integral_functional() const override;
@@ -64,7 +64,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "stress_norm"; }
 
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		IntegrableFunctional get_integral_functional() const override;
@@ -86,7 +86,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "compliance"; }
 
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		IntegrableFunctional get_integral_functional() const override;
@@ -166,7 +166,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "stress"; }
 
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		IntegrableFunctional get_integral_functional() const override;

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
@@ -7,7 +7,7 @@ namespace polyfem::solver
 	class SpatialIntegralForm : public StaticForm
 	{
 	public:
-		SpatialIntegralForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
+		SpatialIntegralForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
 		{
 		}
 
@@ -32,7 +32,7 @@ namespace polyfem::solver
 	class ElasticEnergyForm : public SpatialIntegralForm
 	{
 	public:
-		ElasticEnergyForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		ElasticEnergyForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -51,7 +51,7 @@ namespace polyfem::solver
 	class StressNormForm : public SpatialIntegralForm
 	{
 	public:
-		StressNormForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		StressNormForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -76,7 +76,7 @@ namespace polyfem::solver
 	class ComplianceForm : public SpatialIntegralForm
 	{
 	public:
-		ComplianceForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		ComplianceForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -95,7 +95,7 @@ namespace polyfem::solver
 	class PositionForm : public SpatialIntegralForm
 	{
 	public:
-		PositionForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		PositionForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -117,7 +117,7 @@ namespace polyfem::solver
 	class AccelerationForm : public SpatialIntegralForm
 	{
 	public:
-		AccelerationForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		AccelerationForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -139,7 +139,7 @@ namespace polyfem::solver
 	class KineticForm : public SpatialIntegralForm
 	{
 	public:
-		KineticForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		KineticForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -154,7 +154,7 @@ namespace polyfem::solver
 	class StressForm : public SpatialIntegralForm
 	{
 	public:
-		StressForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		StressForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -177,7 +177,7 @@ namespace polyfem::solver
 	class VolumeForm : public SpatialIntegralForm
 	{
 	public:
-		VolumeForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		VolumeForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
@@ -34,7 +34,7 @@ namespace polyfem::solver
 	public:
 		ElasticEnergyForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -53,7 +53,7 @@ namespace polyfem::solver
 	public:
 		StressNormForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -78,7 +78,7 @@ namespace polyfem::solver
 	public:
 		ComplianceForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -97,7 +97,7 @@ namespace polyfem::solver
 	public:
 		PositionForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -119,7 +119,7 @@ namespace polyfem::solver
 	public:
 		AccelerationForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -141,7 +141,7 @@ namespace polyfem::solver
 	public:
 		KineticForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -156,7 +156,7 @@ namespace polyfem::solver
 	public:
 		StressForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());
@@ -179,7 +179,7 @@ namespace polyfem::solver
 	public:
 		VolumeForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::volume);
+			set_integral_type(SpatialIntegralType::Volume);
 
 			auto tmp_ids = args["volume_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());

--- a/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/SpatialIntegralForms.hpp
@@ -7,7 +7,7 @@ namespace polyfem::solver
 	class SpatialIntegralForm : public StaticForm
 	{
 	public:
-		SpatialIntegralForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
+		SpatialIntegralForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : StaticForm(variable_to_simulations), state_(state)
 		{
 		}
 
@@ -32,7 +32,7 @@ namespace polyfem::solver
 	class ElasticEnergyForm : public SpatialIntegralForm
 	{
 	public:
-		ElasticEnergyForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		ElasticEnergyForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -51,7 +51,7 @@ namespace polyfem::solver
 	class StressNormForm : public SpatialIntegralForm
 	{
 	public:
-		StressNormForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		StressNormForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -76,7 +76,7 @@ namespace polyfem::solver
 	class ComplianceForm : public SpatialIntegralForm
 	{
 	public:
-		ComplianceForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		ComplianceForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -95,7 +95,7 @@ namespace polyfem::solver
 	class PositionForm : public SpatialIntegralForm
 	{
 	public:
-		PositionForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		PositionForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -117,7 +117,7 @@ namespace polyfem::solver
 	class AccelerationForm : public SpatialIntegralForm
 	{
 	public:
-		AccelerationForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		AccelerationForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -139,7 +139,7 @@ namespace polyfem::solver
 	class KineticForm : public SpatialIntegralForm
 	{
 	public:
-		KineticForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		KineticForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -154,7 +154,7 @@ namespace polyfem::solver
 	class StressForm : public SpatialIntegralForm
 	{
 	public:
-		StressForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		StressForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 
@@ -177,7 +177,7 @@ namespace polyfem::solver
 	class VolumeForm : public SpatialIntegralForm
 	{
 	public:
-		VolumeForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		VolumeForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::volume);
 

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
@@ -209,7 +209,7 @@ namespace polyfem::solver
 		have_target_func = true;
 	}
 
-	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const json &args) : StaticForm(variable_to_simulations), state_(state)
+	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args) : StaticForm(variable_to_simulations), state_(state)
 	{
 		std::string target_data_path = args["target_data_path"];
 		if (!std::filesystem::is_regular_file(target_data_path))
@@ -231,7 +231,7 @@ namespace polyfem::solver
 		}
 	}
 
-	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_) : StaticForm(variable_to_simulations), state_(state), target_vertex_positions(target_vertex_positions_), active_nodes(active_nodes_)
+	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_) : StaticForm(variable_to_simulations), state_(state), target_vertex_positions(target_vertex_positions_), active_nodes(active_nodes_)
 	{
 	}
 
@@ -293,7 +293,7 @@ namespace polyfem::solver
 		}
 	}
 
-	BarycenterTargetForm::BarycenterTargetForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2) : StaticForm(variable_to_simulations)
+	BarycenterTargetForm::BarycenterTargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2) : StaticForm(variable_to_simulations)
 	{
 		dim = state1->mesh->dimension();
 		json tmp_args = args;

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
@@ -209,7 +209,7 @@ namespace polyfem::solver
 		have_target_func = true;
 	}
 
-	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args) : StaticForm(variable_to_simulations), state_(state)
+	NodeTargetForm::NodeTargetForm(const State &state, const VariableToSimulationGroup &variable_to_simulations, const json &args) : StaticForm(variable_to_simulations), state_(state)
 	{
 		std::string target_data_path = args["target_data_path"];
 		if (!std::filesystem::is_regular_file(target_data_path))
@@ -231,7 +231,7 @@ namespace polyfem::solver
 		}
 	}
 
-	NodeTargetForm::NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_) : StaticForm(variable_to_simulations), state_(state), target_vertex_positions(target_vertex_positions_), active_nodes(active_nodes_)
+	NodeTargetForm::NodeTargetForm(const State &state, const VariableToSimulationGroup &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_) : StaticForm(variable_to_simulations), state_(state), target_vertex_positions(target_vertex_positions_), active_nodes(active_nodes_)
 	{
 	}
 
@@ -293,7 +293,7 @@ namespace polyfem::solver
 		}
 	}
 
-	BarycenterTargetForm::BarycenterTargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2) : StaticForm(variable_to_simulations)
+	BarycenterTargetForm::BarycenterTargetForm(const VariableToSimulationGroup &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2) : StaticForm(variable_to_simulations)
 	{
 		dim = state1->mesh->dimension();
 		json tmp_args = args;

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
@@ -36,53 +36,34 @@ namespace polyfem::solver
 		{
 			assert(target_state_->diff_cached.size() > 0);
 
-			auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
-				val.setZero(u.rows(), 1);
-				const int e = params["elem"];
-
-				int e_ref;
-				if (auto search = e_to_ref_e_.find(e); search != e_to_ref_e_.end())
+			auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
+				int e_ref = params.elem;
+				if (auto search = e_to_ref_e_.find(params.elem); search != e_to_ref_e_.end())
 					e_ref = search->second;
-				else
-					e_ref = e;
-				const auto &gbase_ref = target_state_->geom_bases()[e_ref];
 
 				Eigen::MatrixXd pts_ref;
-				gbase_ref.eval_geom_mapping(local_pts, pts_ref);
+				target_state_->geom_bases()[e_ref].eval_geom_mapping(local_pts, pts_ref);
 
 				Eigen::MatrixXd u_ref, grad_u_ref;
-				const Eigen::MatrixXd &sol_ref = target_state_->problem->is_time_dependent() ? target_state_->diff_cached.u(params["step"].get<int>()) : target_state_->diff_cached.u(0);
+				const Eigen::VectorXd &sol_ref = target_state_->diff_cached.u(target_state_->problem->is_time_dependent() ? params.step : 0);
 				io::Evaluator::interpolate_at_local_vals(*(target_state_->mesh), target_state_->problem->is_scalar(), target_state_->bases, target_state_->geom_bases(), e_ref, local_pts, sol_ref, u_ref, grad_u_ref);
 
-				for (int q = 0; q < u.rows(); q++)
-				{
-					val(q) = ((u_ref.row(q) + pts_ref.row(q)) - (u.row(q) + pts.row(q))).squaredNorm();
-				}
+				val = (u_ref + pts_ref - u - pts).rowwise().squaredNorm();
 			};
 
-			auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
-				val.setZero(u.rows(), u.cols());
-				const int e = params["elem"];
-
-				int e_ref;
-				if (auto search = e_to_ref_e_.find(e); search != e_to_ref_e_.end())
+			auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
+				int e_ref = params.elem;
+				if (auto search = e_to_ref_e_.find(params.elem); search != e_to_ref_e_.end())
 					e_ref = search->second;
-				else
-					e_ref = e;
-				const auto &gbase_ref = target_state_->geom_bases()[e_ref];
 
 				Eigen::MatrixXd pts_ref;
-				gbase_ref.eval_geom_mapping(local_pts, pts_ref);
+				target_state_->geom_bases()[e_ref].eval_geom_mapping(local_pts, pts_ref);
 
 				Eigen::MatrixXd u_ref, grad_u_ref;
-				const Eigen::MatrixXd &sol_ref = target_state_->problem->is_time_dependent() ? target_state_->diff_cached.u(params["step"].get<int>()) : target_state_->diff_cached.u(0);
+				const Eigen::VectorXd &sol_ref = target_state_->diff_cached.u(target_state_->problem->is_time_dependent() ? params.step : 0);
 				io::Evaluator::interpolate_at_local_vals(*(target_state_->mesh), target_state_->problem->is_scalar(), target_state_->bases, target_state_->geom_bases(), e_ref, local_pts, sol_ref, u_ref, grad_u_ref);
 
-				for (int q = 0; q < u.rows(); q++)
-				{
-					auto x = (u.row(q) + pts.row(q)) - (u_ref.row(q) + pts_ref.row(q));
-					val.row(q) = 2 * x;
-				}
+				val = 2 * (u + pts - u_ref - pts_ref);
 			};
 
 			j.set_j(j_func);
@@ -91,25 +72,21 @@ namespace polyfem::solver
 		}
 		else if (have_target_func)
 		{
-			auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
+			auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 				val.setZero(u.rows(), 1);
 
+				const Eigen::VectorXd X = u + pts;
 				for (int q = 0; q < u.rows(); q++)
-				{
-					Eigen::VectorXd x = u.row(q) + pts.row(q);
-					val(q) = target_func(x(0), x(1), x.size() == 2 ? 0 : x(2), 0, params["elem"]);
-				}
+					val(q) = target_func(X(q, 0), X(q, 1), X.cols() == 2 ? 0 : X(q, 2), 0, params.elem);
 			};
 
-			auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
+			auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 				val.setZero(u.rows(), u.cols());
 
+				const Eigen::VectorXd X = u + pts;
 				for (int q = 0; q < u.rows(); q++)
-				{
-					Eigen::VectorXd x = u.row(q) + pts.row(q);
 					for (int d = 0; d < val.cols(); d++)
-						val(q, d) = target_func_grad[d](x(0), x(1), x.size() == 2 ? 0 : x(2), 0, params["elem"]);
-				}
+						val(q, d) = target_func_grad[d](X(q, 0), X(q, 1), X.cols() == 2 ? 0 : X(q, 2), 0, params.elem);
 			};
 
 			j.set_j(j_func);
@@ -120,7 +97,7 @@ namespace polyfem::solver
 		{
 			if (target_disp.size() == state_.mesh->dimension())
 			{
-				auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
+				auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 					val.setZero(u.rows(), 1);
 
 					for (int q = 0; q < u.rows(); q++)
@@ -132,7 +109,7 @@ namespace polyfem::solver
 						val(q) = err.squaredNorm();
 					}
 				};
-				auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &lambda, const Eigen::MatrixXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const json &params, Eigen::MatrixXd &val) {
+				auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 					val.setZero(u.rows(), u.cols());
 
 					for (int q = 0; q < u.rows(); q++)

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.cpp
@@ -75,7 +75,7 @@ namespace polyfem::solver
 			auto j_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 				val.setZero(u.rows(), 1);
 
-				const Eigen::VectorXd X = u + pts;
+				const Eigen::MatrixXd X = u + pts;
 				for (int q = 0; q < u.rows(); q++)
 					val(q) = target_func(X(q, 0), X(q, 1), X.cols() == 2 ? 0 : X(q, 2), 0, params.elem);
 			};
@@ -83,7 +83,7 @@ namespace polyfem::solver
 			auto djdu_func = [this](const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::VectorXd &lambda, const Eigen::VectorXd &mu, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, const IntegrableFunctional::ParameterType &params, Eigen::MatrixXd &val) {
 				val.setZero(u.rows(), u.cols());
 
-				const Eigen::VectorXd X = u + pts;
+				const Eigen::MatrixXd X = u + pts;
 				for (int q = 0; q < u.rows(); q++)
 					for (int d = 0; d < val.cols(); d++)
 						val(q, d) = target_func_grad[d](X(q, 0), X(q, 1), X.cols() == 2 ? 0 : X(q, 2), 0, params.elem);

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
@@ -12,7 +12,7 @@ namespace polyfem::solver
 	public:
 		TargetForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
-			set_integral_type(SpatialIntegralType::surface);
+			set_integral_type(SpatialIntegralType::Surface);
 
 			auto tmp_ids = args["surface_selection"].get<std::vector<int>>();
 			ids_ = std::set(tmp_ids.begin(), tmp_ids.end());

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
@@ -68,7 +68,7 @@ namespace polyfem::solver
 		double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const override;
 
 	private:
-		std::vector<std::shared_ptr<PositionForm>> center1, center2;
+		std::vector<std::unique_ptr<PositionForm>> center1, center2;
 		int dim;
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
@@ -10,7 +10,7 @@ namespace polyfem::solver
 	class TargetForm : public SpatialIntegralForm
 	{
 	public:
-		TargetForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		TargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::surface);
 
@@ -43,8 +43,8 @@ namespace polyfem::solver
 	class NodeTargetForm : public StaticForm
 	{
 	public:
-		NodeTargetForm(const State &state, const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const json &args);
-		NodeTargetForm(const State &state, const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_);
+		NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args);
+		NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_);
 		~NodeTargetForm() = default;
 
 		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
@@ -61,7 +61,7 @@ namespace polyfem::solver
 	class BarycenterTargetForm : public StaticForm
 	{
 	public:
-		BarycenterTargetForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2);
+		BarycenterTargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2);
 
 		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
 		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
@@ -47,9 +47,9 @@ namespace polyfem::solver
 		NodeTargetForm(const State &state, const VariableToSimulationGroup &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_);
 		~NodeTargetForm() = default;
 
-		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
+		Eigen::VectorXd compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
 		double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const override;
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	protected:
 		const State &state_;
@@ -63,8 +63,8 @@ namespace polyfem::solver
 	public:
 		BarycenterTargetForm(const VariableToSimulationGroup &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2);
 
-		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
-		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		Eigen::VectorXd compute_adjoint_rhs_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
+		void compute_partial_gradient_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 		double value_unweighted_step(const int time_step, const Eigen::VectorXd &x) const override;
 
 	private:

--- a/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TargetForms.hpp
@@ -10,7 +10,7 @@ namespace polyfem::solver
 	class TargetForm : public SpatialIntegralForm
 	{
 	public:
-		TargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
+		TargetForm(const VariableToSimulationGroup &variable_to_simulations, const State &state, const json &args) : SpatialIntegralForm(variable_to_simulations, state, args)
 		{
 			set_integral_type(SpatialIntegralType::surface);
 
@@ -43,8 +43,8 @@ namespace polyfem::solver
 	class NodeTargetForm : public StaticForm
 	{
 	public:
-		NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args);
-		NodeTargetForm(const State &state, const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_);
+		NodeTargetForm(const State &state, const VariableToSimulationGroup &variable_to_simulations, const json &args);
+		NodeTargetForm(const State &state, const VariableToSimulationGroup &variable_to_simulations, const std::vector<int> &active_nodes_, const Eigen::MatrixXd &target_vertex_positions_);
 		~NodeTargetForm() = default;
 
 		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
@@ -61,7 +61,7 @@ namespace polyfem::solver
 	class BarycenterTargetForm : public StaticForm
 	{
 	public:
-		BarycenterTargetForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2);
+		BarycenterTargetForm(const VariableToSimulationGroup &variable_to_simulations, const json &args, const std::shared_ptr<State> &state1, const std::shared_ptr<State> &state2);
 
 		Eigen::VectorXd compute_adjoint_rhs_unweighted_step(const int time_step, const Eigen::VectorXd &x, const State &state) const override;
 		void compute_partial_gradient_unweighted_step(const int time_step, const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;

--- a/src/polyfem/solver/forms/adjoint_forms/TransientForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TransientForm.cpp
@@ -98,7 +98,7 @@ namespace polyfem::solver
 
 		return value;
 	}
-	Eigen::MatrixXd TransientForm::compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const
+	Eigen::MatrixXd TransientForm::compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const
 	{
 		Eigen::MatrixXd terms;
 		terms.setZero(state.ndof(), time_steps_ + 1);
@@ -113,18 +113,18 @@ namespace polyfem::solver
 			{
 				if (weights[i] == 0)
 					continue;
-				local_storage.mat.col(i) = (weights[i] * obj_->weight()) * obj_->compute_adjoint_rhs_unweighted_step(i, x, state);
+				local_storage.mat.col(i) = weights[i] * obj_->compute_adjoint_rhs_step(i, x, state);
 				if (obj_->depends_on_step_prev() && i > 0)
-					local_storage.mat.col(i - 1) = (weights[i] * obj_->weight()) * obj_->compute_adjoint_rhs_unweighted_step_prev(i, x, state);
+					local_storage.mat.col(i - 1) = weights[i] * obj_->compute_adjoint_rhs_step_prev(i, x, state);
 			}
 		});
 
 		for (const LocalThreadMatStorage &local_storage : storage)
 			terms += local_storage.mat;
 
-		return terms;
+		return terms * weight();
 	}
-	void TransientForm::compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void TransientForm::compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		gradv.setZero(x.size());
 		std::vector<double> weights = get_transient_quadrature_weights();
@@ -138,13 +138,14 @@ namespace polyfem::solver
 			{
 				if (weights[i] == 0)
 					continue;
-				obj_->compute_partial_gradient_unweighted_step(i, x, tmp);
-				local_storage.mat += (weights[i] * obj_->weight()) * tmp;
+				obj_->compute_partial_gradient_step(i, x, tmp);
+				local_storage.mat += weights[i] * tmp;
 			}
 		});
 
 		for (const LocalThreadMatStorage &local_storage : storage)
 			gradv += local_storage.mat;
+		gradv *= weight();
 	}
 
 	void TransientForm::init(const Eigen::VectorXd &x)
@@ -189,27 +190,6 @@ namespace polyfem::solver
 			obj_->solution_changed_step(i, new_x);
 		}
 	}
-
-	void TransientForm::update_quantities(const double t, const Eigen::VectorXd &x)
-	{
-		obj_->update_quantities(t, x);
-	}
-
-	void TransientForm::init_lagging(const Eigen::VectorXd &x)
-	{
-		obj_->init_lagging(x);
-	}
-
-	void TransientForm::update_lagging(const Eigen::VectorXd &x, const int iter_num)
-	{
-		obj_->update_lagging(x, iter_num);
-	}
-
-	void TransientForm::set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC)
-	{
-		obj_->set_apply_DBC(x, apply_DBC);
-	}
-
 	bool TransientForm::is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const
 	{
 		return obj_->is_step_collision_free(x0, x1);

--- a/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
@@ -7,7 +7,7 @@ namespace polyfem::solver
 	class TransientForm : public AdjointForm
 	{
 	public:
-		TransientForm(const std::vector<std::shared_ptr<VariableToSimulation>> &variable_to_simulations, const int time_steps, const double dt, const std::string &transient_integral_type, const std::vector<int> &steps, const std::shared_ptr<StaticForm> &obj) : AdjointForm(variable_to_simulations), time_steps_(time_steps), dt_(dt), transient_integral_type_(transient_integral_type), steps_(steps), obj_(obj) {}
+		TransientForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const int time_steps, const double dt, const std::string &transient_integral_type, const std::vector<int> &steps, const std::shared_ptr<StaticForm> &obj) : AdjointForm(variable_to_simulations), time_steps_(time_steps), dt_(dt), transient_integral_type_(transient_integral_type), steps_(steps), obj_(obj) {}
 		virtual ~TransientForm() = default;
 
 		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;

--- a/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
@@ -10,8 +10,8 @@ namespace polyfem::solver
 		TransientForm(const VariableToSimulationGroup &variable_to_simulations, const int time_steps, const double dt, const std::string &transient_integral_type, const std::vector<int> &steps, const std::shared_ptr<StaticForm> &obj) : AdjointForm(variable_to_simulations), time_steps_(time_steps), dt_(dt), transient_integral_type_(transient_integral_type), steps_(steps), obj_(obj) {}
 		virtual ~TransientForm() = default;
 
-		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;
-		void compute_partial_gradient_unweighted(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		Eigen::MatrixXd compute_adjoint_rhs(const Eigen::VectorXd &x, const State &state) const override;
+		void compute_partial_gradient(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 		void init(const Eigen::VectorXd &x) override;
 		bool is_step_valid(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override;
@@ -20,10 +20,6 @@ namespace polyfem::solver
 		void line_search_end() override;
 		void post_step(const polysolve::nonlinear::PostStepData &data) override;
 		void solution_changed(const Eigen::VectorXd &new_x) override;
-		void update_quantities(const double t, const Eigen::VectorXd &x) override;
-		void init_lagging(const Eigen::VectorXd &x) override;
-		void update_lagging(const Eigen::VectorXd &x, const int iter_num) override;
-		void set_apply_DBC(const Eigen::VectorXd &x, bool apply_DBC) override;
 		bool is_step_collision_free(const Eigen::VectorXd &x0, const Eigen::VectorXd &x1) const override;
 
 	protected:

--- a/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/TransientForm.hpp
@@ -7,7 +7,7 @@ namespace polyfem::solver
 	class TransientForm : public AdjointForm
 	{
 	public:
-		TransientForm(const std::vector<std::unique_ptr<VariableToSimulation>> &variable_to_simulations, const int time_steps, const double dt, const std::string &transient_integral_type, const std::vector<int> &steps, const std::shared_ptr<StaticForm> &obj) : AdjointForm(variable_to_simulations), time_steps_(time_steps), dt_(dt), transient_integral_type_(transient_integral_type), steps_(steps), obj_(obj) {}
+		TransientForm(const VariableToSimulationGroup &variable_to_simulations, const int time_steps, const double dt, const std::string &transient_integral_type, const std::vector<int> &steps, const std::shared_ptr<StaticForm> &obj) : AdjointForm(variable_to_simulations), time_steps_(time_steps), dt_(dt), transient_integral_type_(transient_integral_type), steps_(steps), obj_(obj) {}
 		virtual ~TransientForm() = default;
 
 		Eigen::MatrixXd compute_adjoint_rhs_unweighted(const Eigen::VectorXd &x, const State &state) const override;

--- a/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.cpp
@@ -131,12 +131,7 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_shape_transient_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_shape_transient_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
 				AdjointTools::dJ_shape_static_adjoint_term(*state, state->diff_cached.u(0), state->get_adjoint_mat(0), cur_term);
 
@@ -184,16 +179,10 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_material_transient_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_material_transient_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
-			{
 				AdjointTools::dJ_material_static_adjoint_term(*state, state->diff_cached.u(0), state->get_adjoint_mat(0), cur_term);
-			}
+
 			if (term.size() != cur_term.size())
 				term = cur_term;
 			else
@@ -253,16 +242,10 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_friction_transient_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_friction_transient_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
-			{
 				log_and_throw_adjoint_error("[{}] Gradient in static simulations not implemented!", name());
-			}
+
 			if (term.size() != cur_term.size())
 				term = cur_term;
 			else
@@ -310,16 +293,10 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_damping_transient_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_damping_transient_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
-			{
 				log_and_throw_adjoint_error("[{}] Static simulation not supported!", name());
-			}
+
 			if (term.size() != cur_term.size())
 				term = cur_term;
 			else
@@ -351,16 +328,10 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_initial_condition_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_initial_condition_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
-			{
 				log_and_throw_adjoint_error("[{}] Static simulation not supported!", name());
-			}
+
 			if (term.size() != cur_term.size())
 				term = cur_term;
 			else
@@ -402,16 +373,10 @@ namespace polyfem::solver
 		for (auto state : states_)
 		{
 			if (state->problem->is_time_dependent())
-			{
-				Eigen::MatrixXd adjoint_nu, adjoint_p;
-				adjoint_nu = state->get_adjoint_mat(1);
-				adjoint_p = state->get_adjoint_mat(0);
-				AdjointTools::dJ_dirichlet_transient_adjoint_term(*state, adjoint_nu, adjoint_p, cur_term);
-			}
+				AdjointTools::dJ_dirichlet_transient_adjoint_term(*state, state->get_adjoint_mat(1), state->get_adjoint_mat(0), cur_term);
 			else
-			{
 				log_and_throw_adjoint_error("[{}] Static dirichlet boundary optimization not supported!", name());
-			}
+
 			if (term.size() != cur_term.size())
 				term = cur_term;
 			else

--- a/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp
@@ -40,6 +40,37 @@ namespace polyfem::solver
 		Eigen::VectorXi output_indexing_; // if a derived class overrides apply_parametrization_jacobian(term, x), this is not necessarily used.
 	};
 
+	class VariableToSimulationGroup
+	{
+	public:
+		using ValueType = std::shared_ptr<VariableToSimulation>;
+
+		VariableToSimulationGroup() = default;
+
+		void init(const json& args, const std::vector<std::shared_ptr<State>> &states, const std::vector<int> &variable_sizes);
+
+		inline void update(const Eigen::VectorXd &x)
+		{
+			for (auto &v2s : L)
+				v2s->update(x);
+		}
+
+		Eigen::VectorXd compute_adjoint_term(const Eigen::VectorXd &x) const;
+
+		typedef std::vector<ValueType>::iterator iterator;
+		typedef std::vector<ValueType>::const_iterator const_iterator;
+
+		inline ValueType& operator[](size_t i) { return L[i]; }
+		inline iterator begin() { return L.begin(); }
+		inline iterator end() { return L.end(); }
+		inline const_iterator begin() const { return L.begin(); }
+		inline const_iterator end() const { return L.end(); }
+		inline void push_back(const ValueType &v2s) { L.push_back(v2s); }
+		inline void clear() { L.clear(); }
+	private:
+		std::vector<ValueType> L;
+	};
+
 	// state variable dof = dim * n_vertices
 	class ShapeVariableToSimulation : public VariableToSimulation
 	{

--- a/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/VariableToSimulation.hpp
@@ -118,7 +118,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "elastic"; }
 
-		ParameterType get_parameter_type() const override { return ParameterType::Material; }
+		ParameterType get_parameter_type() const override { return ParameterType::LameParameter; }
 
 		Eigen::VectorXd compute_adjoint_term(const Eigen::VectorXd &x) const override;
 		virtual Eigen::VectorXd inverse_eval() override;
@@ -137,7 +137,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "friction"; }
 
-		ParameterType get_parameter_type() const override { return ParameterType::FrictionCoeff; }
+		ParameterType get_parameter_type() const override { return ParameterType::FrictionCoefficient; }
 
 		Eigen::VectorXd compute_adjoint_term(const Eigen::VectorXd &x) const override;
 		virtual Eigen::VectorXd inverse_eval() override;
@@ -156,7 +156,7 @@ namespace polyfem::solver
 
 		std::string name() const override { return "damping"; }
 
-		ParameterType get_parameter_type() const override { return ParameterType::DampingCoeff; }
+		ParameterType get_parameter_type() const override { return ParameterType::DampingCoefficient; }
 
 		Eigen::VectorXd compute_adjoint_term(const Eigen::VectorXd &x) const override;
 		virtual Eigen::VectorXd inverse_eval() override;

--- a/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.cpp
@@ -17,7 +17,7 @@ namespace polyfem::solver
 		return val;
 	}
 
-	void WeightedVolumeForm::compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	void WeightedVolumeForm::compute_partial_gradient_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
 	{
 		assert(x.size() == state_.mesh->n_elements());
 
@@ -28,6 +28,6 @@ namespace polyfem::solver
 			state_.ass_vals_cache.compute(e, state_.mesh->is_volume(), state_.bases[e], state_.geom_bases()[e], vals);
 			gradv(e) = (vals.det.array() * vals.quadrature.weights.array()).sum();
 		}
-		// gradv *= weight();
+		gradv *= weight();
 	}
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.cpp
+++ b/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.cpp
@@ -1,0 +1,33 @@
+#include "WeightedVolumeForm.hpp"
+#include <polyfem/State.hpp>
+
+namespace polyfem::solver
+{
+	double WeightedVolumeForm::value_unweighted_with_param(const Eigen::VectorXd &x) const
+	{
+		assert(x.size() == state_.mesh->n_elements());
+
+		double val = 0;
+		assembler::ElementAssemblyValues vals;
+		for (int e = 0; e < state_.bases.size(); e++)
+		{
+			state_.ass_vals_cache.compute(e, state_.mesh->is_volume(), state_.bases[e], state_.geom_bases()[e], vals);
+			val += (vals.det.array() * vals.quadrature.weights.array()).sum() * x(e);
+		}
+		return val;
+	}
+
+	void WeightedVolumeForm::compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const
+	{
+		assert(x.size() == state_.mesh->n_elements());
+
+		gradv.setZero(x.size());
+		assembler::ElementAssemblyValues vals;
+		for (int e = 0; e < state_.bases.size(); e++)
+		{
+			state_.ass_vals_cache.compute(e, state_.mesh->is_volume(), state_.bases[e], state_.geom_bases()[e], vals);
+			gradv(e) = (vals.det.array() * vals.quadrature.weights.array()).sum();
+		}
+		// gradv *= weight();
+	}
+} // namespace polyfem::solver

--- a/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
@@ -19,7 +19,7 @@ namespace polyfem::solver
 		double value_unweighted_with_param(const Eigen::VectorXd &x) const override;
 
 		/// @brief Computes the gradient of this form wrt. x, assuming that the volume of elements doesn't depend on x
-		void compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
+		void compute_partial_gradient_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	private:
 		const State &state_;

--- a/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
@@ -5,39 +5,21 @@
 
 namespace polyfem::solver
 {
+	/// @brief Computes the dot product of the input x (after parametrization) and the volume of each element on the mesh
 	class WeightedVolumeForm : public ParametrizationForm
 	{
 	public:
-		WeightedVolumeForm(const CompositeParametrization &parametrizations, const State &state) : ParametrizationForm(parametrizations), state_(state)
+		WeightedVolumeForm(const CompositeParametrization &parametrizations, const State &state)
+			: ParametrizationForm(parametrizations), state_(state)
 		{
 		}
 
-		inline double value_unweighted_with_param(const Eigen::VectorXd &x) const override
-		{
-			assert(x.size() == state_.mesh->n_elements());
+	protected:
+		/// @param x The input vector, after parametrization, same size as the number of elements on the mesh
+		double value_unweighted_with_param(const Eigen::VectorXd &x) const override;
 
-			double val = 0;
-			assembler::ElementAssemblyValues vals;
-			for (int e = 0; e < state_.bases.size(); e++)
-			{
-				state_.ass_vals_cache.compute(e, state_.mesh->is_volume(), state_.bases[e], state_.geom_bases()[e], vals);
-				val += (vals.det.array() * vals.quadrature.weights.array()).sum() * x(e);
-			}
-			return val;
-		}
-
-		inline void first_derivative_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override
-		{
-			assert(x.size() == state_.mesh->n_elements());
-
-			gradv.setZero(x.size());
-			assembler::ElementAssemblyValues vals;
-			for (int e = 0; e < state_.bases.size(); e++)
-			{
-				state_.ass_vals_cache.compute(e, state_.mesh->is_volume(), state_.bases[e], state_.geom_bases()[e], vals);
-				gradv(e) = (vals.det.array() * vals.quadrature.weights.array()).sum();
-			}
-		}
+		/// @brief Computes the gradient of this form wrt. x, assuming that the volume of elements doesn't depend on x
+		void compute_partial_gradient_unweighted_with_param(const Eigen::VectorXd &x, Eigen::VectorXd &gradv) const override;
 
 	private:
 		const State &state_;

--- a/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
+++ b/src/polyfem/solver/forms/adjoint_forms/WeightedVolumeForm.hpp
@@ -9,8 +9,8 @@ namespace polyfem::solver
 	class WeightedVolumeForm : public ParametrizationForm
 	{
 	public:
-		WeightedVolumeForm(const CompositeParametrization &parametrizations, const State &state)
-			: ParametrizationForm(parametrizations), state_(state)
+		WeightedVolumeForm(CompositeParametrization &&parametrizations, const State &state)
+			: ParametrizationForm(std::move(parametrizations)), state_(state)
 		{
 		}
 

--- a/src/polyfem/solver/forms/parametrization/Parametrization.hpp
+++ b/src/polyfem/solver/forms/parametrization/Parametrization.hpp
@@ -26,7 +26,7 @@ namespace polyfem::solver
 	class CompositeParametrization : public Parametrization
 	{
 	public:
-		CompositeParametrization() {}
+		CompositeParametrization() : parametrizations_(std::vector<std::shared_ptr<Parametrization>>()) {}
 		CompositeParametrization(std::vector<std::shared_ptr<Parametrization>>&& parametrizations) : parametrizations_(parametrizations) {}
 		virtual ~CompositeParametrization() {}
 
@@ -37,6 +37,6 @@ namespace polyfem::solver
 		Eigen::VectorXd apply_jacobian(const Eigen::VectorXd &grad_full, const Eigen::VectorXd &x) const override;
 
 	private:
-		std::vector<std::shared_ptr<Parametrization>> parametrizations_;
+		const std::vector<std::shared_ptr<Parametrization>> parametrizations_;
 	};
 } // namespace polyfem::solver

--- a/src/polyfem/solver/forms/parametrization/Parametrization.hpp
+++ b/src/polyfem/solver/forms/parametrization/Parametrization.hpp
@@ -27,7 +27,7 @@ namespace polyfem::solver
 	{
 	public:
 		CompositeParametrization() {}
-		CompositeParametrization(const std::vector<std::shared_ptr<Parametrization>> &parametrizations) : parametrizations_(parametrizations) {}
+		CompositeParametrization(std::vector<std::shared_ptr<Parametrization>>&& parametrizations) : parametrizations_(parametrizations) {}
 		virtual ~CompositeParametrization() {}
 
 		Eigen::VectorXd inverse_eval(const Eigen::VectorXd &y) override;

--- a/src/polyfem/state/StateDiff.cpp
+++ b/src/polyfem/state/StateDiff.cpp
@@ -459,7 +459,7 @@ namespace polyfem
 				// TODO: generalize to BDFn
 				Eigen::VectorXd tmp = rhs_(boundary_nodes);
 				if (i + 1 < cols_per_adjoint)
-					tmp += -2. / beta_dt * adjoints(boundary_nodes, i + 1);
+					tmp += (-2. / beta_dt) * adjoints(boundary_nodes, i + 1);
 				if (i + 2 < cols_per_adjoint)
 					tmp += (1. / beta_dt) * adjoints(boundary_nodes, i + 2);
 

--- a/src/polyfem/state/StateDiff.cpp
+++ b/src/polyfem/state/StateDiff.cpp
@@ -320,18 +320,12 @@ namespace polyfem
 	{
 		Eigen::MatrixXd b = adjoint_rhs;
 
-		Eigen::MatrixXd adjoint;
-		adjoint.setZero(ndof(), adjoint_rhs.cols());
+		Eigen::MatrixXd adjoint = Eigen::MatrixXd::Zero(ndof(), adjoint_rhs.cols());
 		if (lin_solver_cached)
 		{
-			for (int i : boundary_nodes)
-				b.row(i).setZero();
+			b(boundary_nodes, Eigen::all).setZero();
 
 			StiffnessMatrix A = diff_cached.gradu_h(0);
-			const int full_size = A.rows();
-			const int problem_dim = problem->is_scalar() ? 1 : mesh->dimension();
-			int precond_num = problem_dim * n_bases;
-
 			for (int i = 0; i < b.cols(); i++)
 			{
 				Eigen::VectorXd x, tmp;
@@ -348,36 +342,18 @@ namespace polyfem
 			solver->analyze_pattern(A, A.rows());
 			solver->factorize(A);
 
-			if (true) // (disp_grad_.size() == 0)
+			for (int i = 0; i < b.cols(); i++)
 			{
-				for (int i = 0; i < b.cols(); i++)
-				{
-					Eigen::MatrixXd tmp = b.col(i);
+				Eigen::MatrixXd tmp = b.col(i);
 
-					Eigen::VectorXd x;
-					x.setZero(tmp.size());
-					solver->solve(tmp, x);
+				Eigen::VectorXd x;
+				x.setZero(tmp.size());
+				solver->solve(tmp, x);
 
-					adjoint.col(i) = solve_data.nl_problem->reduced_to_full(x);
-				}
-				// NLProblem sets dirichlet values to forward BC values, but we want zero in adjoint
-				adjoint(boundary_nodes, Eigen::all).setZero();
+				adjoint.col(i) = solve_data.nl_problem->reduced_to_full(x);
 			}
-			else
-			{
-				adjoint.setZero(adjoint_rhs.rows(), adjoint_rhs.cols());
-				for (int i = 0; i < b.cols(); i++)
-				{
-					Eigen::MatrixXd tmp = b.col(i);
-
-					Eigen::VectorXd x;
-					x.setZero(tmp.size());
-					solver->solve(tmp, x);
-					x.conservativeResize(adjoint.rows());
-
-					adjoint.col(i) = x;
-				}
-			}
+			// NLProblem sets dirichlet values to forward BC values, but we want zero in adjoint
+			adjoint(boundary_nodes, Eigen::all).setZero();
 		}
 
 		return adjoint;
@@ -417,7 +393,7 @@ namespace polyfem
 
 				const int num = std::min(bdf_order, time_steps - i);
 
-				Eigen::VectorXd bdf_coeffs(num);
+				Eigen::VectorXd bdf_coeffs = Eigen::VectorXd::Zero(num);
 				for (int j = 0; j < bdf_order && i + j < time_steps; ++j)
 					bdf_coeffs(j) = -time_integrator::BDF::alphas(std::min(bdf_order - 1, i + j))[j];
 

--- a/src/polyfem/utils/CMakeLists.txt
+++ b/src/polyfem/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
 	GeometryUtils.hpp
 	getRSS.c
 	HashUtils.hpp
+	IntegrableFunctional.hpp
 	InterpolatedFunction.cpp
 	InterpolatedFunction.hpp
 	Interpolation.cpp

--- a/src/polyfem/utils/CMakeLists.txt
+++ b/src/polyfem/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
 	GeometryUtils.hpp
 	getRSS.c
 	HashUtils.hpp
+	IntegrableFunctional.cpp
 	IntegrableFunctional.hpp
 	InterpolatedFunction.cpp
 	InterpolatedFunction.hpp

--- a/src/polyfem/utils/IntegrableFunctional.cpp
+++ b/src/polyfem/utils/IntegrableFunctional.cpp
@@ -2,72 +2,72 @@
 
 namespace polyfem
 {
-	void IntegrableFunctional::set_j(const functionalType &j_)
+	void IntegrableFunctional::set_j(const functionalType &j)
 	{
-		j_func = j_;
+		j_func_ = j;
 	}
-	void IntegrableFunctional::set_dj_dx(const functionalType &dj_dx_)
+	void IntegrableFunctional::set_dj_dx(const functionalType &dj_dx)
 	{
-		dj_dx_func = dj_dx_;
+		dj_dx_func_ = dj_dx;
 		has_x = true;
 	}
-	void IntegrableFunctional::set_dj_du(const functionalType &dj_du_)
+	void IntegrableFunctional::set_dj_du(const functionalType &dj_du)
 	{
-		dj_du_func = dj_du_;
+		dj_du_func_ = dj_du;
 		assert(!has_gradu && !has_gradu_local);
 		has_u = true;
 	}
-	void IntegrableFunctional::set_dj_dgradu(const functionalType &dj_dgradu_)
+	void IntegrableFunctional::set_dj_dgradu(const functionalType &dj_dgradu)
 	{
-		dj_dgradu_func = dj_dgradu_;
+		dj_dgradu_func_ = dj_dgradu;
 		assert(!has_u && !has_gradu_local);
 		has_gradu = true;
 	}
-	void IntegrableFunctional::set_dj_dgradu_local(const functionalType &dj_dgradu_local_)
+	void IntegrableFunctional::set_dj_dgradu_local(const functionalType &dj_dgradu_local)
 	{
-		dj_dgradu_local_func = dj_dgradu_local_;
+		dj_dgradu_local_func_ = dj_dgradu_local;
 		assert(!has_u && !has_gradu);
 		has_gradu_local = true;
 	}
-	void IntegrableFunctional::set_dj_dgradx(const functionalType &dj_dgradx_)
+	void IntegrableFunctional::set_dj_dgradx(const functionalType &dj_dgradx)
 	{
-		dj_dgradx_func = dj_dgradx_;
+		dj_dgradx_func_ = dj_dgradx;
 		has_gradx = true;
 	}
 
 	void IntegrableFunctional::evaluate(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
-		assert(j_func);
-		j_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		assert(j_func_);
+		j_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 
 	void IntegrableFunctional::dj_dx(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
 		assert(has_x);
-		dj_dx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		dj_dx_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 
 	void IntegrableFunctional::dj_du(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
 		assert(has_u);
-		dj_du_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		dj_du_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 
 	void IntegrableFunctional::dj_dgradu(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
 		assert(has_gradu);
-		dj_dgradu_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		dj_dgradu_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 
 	void IntegrableFunctional::dj_dgradu_local(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
 		assert(has_gradu_local);
-		dj_dgradu_local_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		dj_dgradu_local_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 
 	void IntegrableFunctional::dj_dgradx(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
 	{
 		assert(has_gradx);
-		dj_dgradx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+		dj_dgradx_func_(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 	}
 } // namespace polyfem

--- a/src/polyfem/utils/IntegrableFunctional.cpp
+++ b/src/polyfem/utils/IntegrableFunctional.cpp
@@ -1,0 +1,73 @@
+#include "IntegrableFunctional.hpp"
+
+namespace polyfem
+{
+	void IntegrableFunctional::set_j(const functionalType &j_)
+	{
+		j_func = j_;
+	}
+	void IntegrableFunctional::set_dj_dx(const functionalType &dj_dx_)
+	{
+		dj_dx_func = dj_dx_;
+		has_x = true;
+	}
+	void IntegrableFunctional::set_dj_du(const functionalType &dj_du_)
+	{
+		dj_du_func = dj_du_;
+		assert(!has_gradu && !has_gradu_local);
+		has_u = true;
+	}
+	void IntegrableFunctional::set_dj_dgradu(const functionalType &dj_dgradu_)
+	{
+		dj_dgradu_func = dj_dgradu_;
+		assert(!has_u && !has_gradu_local);
+		has_gradu = true;
+	}
+	void IntegrableFunctional::set_dj_dgradu_local(const functionalType &dj_dgradu_local_)
+	{
+		dj_dgradu_local_func = dj_dgradu_local_;
+		assert(!has_u && !has_gradu);
+		has_gradu_local = true;
+	}
+	void IntegrableFunctional::set_dj_dgradx(const functionalType &dj_dgradx_)
+	{
+		dj_dgradx_func = dj_dgradx_;
+		has_gradx = true;
+	}
+
+	void IntegrableFunctional::evaluate(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(j_func);
+		j_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+
+	void IntegrableFunctional::dj_dx(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(has_x);
+		dj_dx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+
+	void IntegrableFunctional::dj_du(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(has_u);
+		dj_du_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+
+	void IntegrableFunctional::dj_dgradu(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(has_gradu);
+		dj_dgradu_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+
+	void IntegrableFunctional::dj_dgradu_local(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(has_gradu_local);
+		dj_dgradu_local_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+
+	void IntegrableFunctional::dj_dgradx(const Eigen::MatrixXd &elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const
+	{
+		assert(has_gradx);
+		dj_dgradx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
+	}
+} // namespace polyfem

--- a/src/polyfem/utils/IntegrableFunctional.hpp
+++ b/src/polyfem/utils/IntegrableFunctional.hpp
@@ -13,119 +13,43 @@ namespace polyfem
 	class IntegrableFunctional
 	{
 	public:
-		typedef std::function<void(const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const assembler::ElementAssemblyValues &, const json &, Eigen::MatrixXd &)> functionalType;
+		/// @brief Parameters for the functional evaluation
+		struct ParameterType
+		{
+			double t = 0.;
+			int step = 0;
+			int elem = -1;
+
+			int node = -1;
+			int body_id = -1;
+			int boundary_id = -1;
+		};
+
+		typedef std::function<void(const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::MatrixXd &, const Eigen::VectorXd &, const Eigen::VectorXd &, const Eigen::MatrixXd &, const assembler::ElementAssemblyValues &, const ParameterType &, Eigen::MatrixXd &)> functionalType;
 
 		IntegrableFunctional() = default;
 
-		void set_name(const std::string &name_) { name = name_; }
-		std::string get_name() const { return name; }
+		void set_j(const functionalType &j_);
+		void set_dj_dx(const functionalType &dj_dx_);
+		void set_dj_du(const functionalType &dj_du_);
+		void set_dj_dgradu(const functionalType &dj_dgradu_);
+		void set_dj_dgradu_local(const functionalType &dj_dgradu_local_);
+		void set_dj_dgradx(const functionalType &dj_dgradx_);
 
-		void set_j(const functionalType &j_) { j_func = j_; }
-		void set_dj_dx(const functionalType &dj_dx_)
-		{
-			dj_dx_func = dj_dx_;
-			has_x = true;
-		}
-		void set_dj_du(const functionalType &dj_du_)
-		{
-			dj_du_func = dj_du_;
-			has_u = true;
-		}
-		void set_dj_dgradu(const functionalType &dj_dgradu_)
-		{
-			dj_dgradu_func = dj_dgradu_;
-			has_gradu = true;
-		}
-		void set_dj_dgradu_local(const functionalType &dj_dgradu_local_)
-		{
-			dj_dgradu_local_func = dj_dgradu_local_;
-			has_gradu_local = true;
-		}
-		void set_dj_dgradx(const functionalType &dj_dgradx_)
-		{
-			dj_dgradx_func = dj_dgradx_;
-			has_gradx = true;
-		}
+		void evaluate(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
+		void dj_dx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
+		void dj_du(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
+		void dj_dgradu(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
+		void dj_dgradu_local(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
+		void dj_dgradx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
 
-		void evaluate(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(j_func);
-			j_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-		}
-
-		void dj_dx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(has_x);
-			if (dj_dx_func)
-			{
-				dj_dx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-			}
-			else
-			{
-				// TODO: Use AutoDiff
-			}
-		}
-
-		void dj_du(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(has_u);
-			if (dj_du_func)
-			{
-				dj_du_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-			}
-			else
-			{
-				// TODO: Use AutoDiff
-			}
-		}
-
-		void dj_dgradu(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(has_gradu);
-			if (dj_dgradu_func)
-			{
-				dj_dgradu_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-			}
-			else
-			{
-				// TODO: Use AutoDiff
-			}
-		}
-
-		void dj_dgradu_local(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(has_gradu_local);
-			if (dj_dgradu_local_func)
-			{
-				dj_dgradu_local_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-			}
-			else
-			{
-				// TODO: Use AutoDiff
-			}
-		}
-
-		void dj_dgradx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
-		{
-			assert(has_gradx);
-			if (dj_dgradx_func)
-			{
-				dj_dgradx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
-			}
-			else
-			{
-				// TODO: Use AutoDiff
-			}
-		}
-
-		bool depend_on_x() const { return has_x; }
-		bool depend_on_u() const { return has_u; }
-		bool depend_on_gradu() const { return has_gradu; }
-		bool depend_on_gradu_local() const { return has_gradu_local; }
-		bool depend_on_gradx() const { return has_gradx; }
+		inline bool depend_on_x() const { return has_x; }
+		inline bool depend_on_u() const { return has_u; }
+		inline bool depend_on_gradu() const { return has_gradu; }
+		inline bool depend_on_gradu_local() const { return has_gradu_local; }
+		inline bool depend_on_gradx() const { return has_gradx; }
 
 	private:
-		std::string name = "";
 		bool has_x = false, has_u = false, has_gradu = false, has_gradu_local = false, has_gradx = false;
 		functionalType j_func, dj_dx_func, dj_du_func, dj_dgradu_func, dj_dgradu_local_func, dj_dgradx_func;
 	};

--- a/src/polyfem/utils/IntegrableFunctional.hpp
+++ b/src/polyfem/utils/IntegrableFunctional.hpp
@@ -29,12 +29,12 @@ namespace polyfem
 
 		IntegrableFunctional() = default;
 
-		void set_j(const functionalType &j_);
-		void set_dj_dx(const functionalType &dj_dx_);
-		void set_dj_du(const functionalType &dj_du_);
-		void set_dj_dgradu(const functionalType &dj_dgradu_);
-		void set_dj_dgradu_local(const functionalType &dj_dgradu_local_);
-		void set_dj_dgradx(const functionalType &dj_dgradx_);
+		void set_j(const functionalType &j);
+		void set_dj_dx(const functionalType &dj_dx);
+		void set_dj_du(const functionalType &dj_du);
+		void set_dj_dgradu(const functionalType &dj_dgradu);
+		void set_dj_dgradu_local(const functionalType &dj_dgradu_local);
+		void set_dj_dgradx(const functionalType &dj_dgradx);
 
 		void evaluate(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
 		void dj_dx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, ParameterType &params, Eigen::MatrixXd &val) const;
@@ -51,6 +51,6 @@ namespace polyfem
 
 	private:
 		bool has_x = false, has_u = false, has_gradu = false, has_gradu_local = false, has_gradx = false;
-		functionalType j_func, dj_dx_func, dj_du_func, dj_dgradu_func, dj_dgradu_local_func, dj_dgradx_func;
+		functionalType j_func_, dj_dx_func_, dj_du_func_, dj_dgradu_func_, dj_dgradu_local_func_, dj_dgradx_func_;
 	};
 } // namespace polyfem

--- a/src/polyfem/utils/IntegrableFunctional.hpp
+++ b/src/polyfem/utils/IntegrableFunctional.hpp
@@ -47,22 +47,18 @@ namespace polyfem
 			has_gradx = true;
 		}
 
-		void evaluate(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void evaluate(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(j_func);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
-			j_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+			j_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 		}
 
-		void dj_dx(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void dj_dx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(has_x);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
 			if (dj_dx_func)
 			{
-				dj_dx_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+				dj_dx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 			}
 			else
 			{
@@ -70,14 +66,12 @@ namespace polyfem
 			}
 		}
 
-		void dj_du(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void dj_du(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(has_u);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
 			if (dj_du_func)
 			{
-				dj_du_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+				dj_du_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 			}
 			else
 			{
@@ -85,14 +79,12 @@ namespace polyfem
 			}
 		}
 
-		void dj_dgradu(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void dj_dgradu(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(has_gradu);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
 			if (dj_dgradu_func)
 			{
-				dj_dgradu_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+				dj_dgradu_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 			}
 			else
 			{
@@ -100,14 +92,12 @@ namespace polyfem
 			}
 		}
 
-		void dj_dgradu_local(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void dj_dgradu_local(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(has_gradu_local);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
 			if (dj_dgradu_local_func)
 			{
-				dj_dgradu_local_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+				dj_dgradu_local_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 			}
 			else
 			{
@@ -115,14 +105,12 @@ namespace polyfem
 			}
 		}
 
-		void dj_dgradx(const std::map<std::string, Assembler::ParamFunc> &lame_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
+		void dj_dgradx(const Eigen::MatrixXd& elastic_params, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, const Eigen::MatrixXd &u, const Eigen::MatrixXd &grad_u, const Eigen::MatrixXd &reference_normals, const assembler::ElementAssemblyValues &vals, json &params, Eigen::MatrixXd &val) const
 		{
 			assert(has_gradx);
-			Eigen::MatrixXd lambda, mu;
-			lambda_mu(lame_params, params["elem"], local_pts, pts, lambda, mu);
 			if (dj_dgradx_func)
 			{
-				dj_dgradx_func(local_pts, pts, u, grad_u, lambda, mu, reference_normals, vals, params, val);
+				dj_dgradx_func(local_pts, pts, u, grad_u, elastic_params.col(0), elastic_params.col(1), reference_normals, vals, params, val);
 			}
 			else
 			{
@@ -137,25 +125,6 @@ namespace polyfem
 		bool depend_on_gradx() const { return has_gradx; }
 
 	private:
-		void lambda_mu(const std::map<std::string, Assembler::ParamFunc> &lame_params, const int e, const Eigen::MatrixXd &local_pts, const Eigen::MatrixXd &pts, Eigen::MatrixXd &lambda, Eigen::MatrixXd &mu) const
-		{
-			const double t = 0;
-			lambda.setZero(local_pts.rows(), 1);
-			mu.setZero(local_pts.rows(), 1);
-
-			auto search_lambda = lame_params.find("lambda");
-			auto search_mu = lame_params.find("mu");
-
-			if (search_lambda == lame_params.end() || search_mu == lame_params.end())
-				return;
-
-			for (int p = 0; p < local_pts.rows(); p++)
-			{
-				lambda(p) = search_lambda->second(local_pts.row(p), pts.row(p), t, e);
-				mu(p) = search_mu->second(local_pts.row(p), pts.row(p), t, e);
-			}
-		}
-
 		std::string name = "";
 		bool has_x = false, has_u = false, has_gradu = false, has_gradu_local = false, has_gradx = false;
 		functionalType j_func, dj_dx_func, dj_du_func, dj_dgradu_func, dj_dgradu_local_func, dj_dgradx_func;

--- a/tests/test_diff.cpp
+++ b/tests/test_diff.cpp
@@ -153,7 +153,7 @@ TEST_CASE("laplacian", "[test_adjoint]")
 	Eigen::MatrixXd velocity_discrete;
 	sample_field(*states[0], velocity, velocity_discrete);
 
-	verify_adjoint(*nl_problem, x, velocity_discrete, 1e-7, 3e-5);
+	verify_adjoint(*nl_problem, x, velocity_discrete, 1e-7, 1e-8);
 }
 
 TEST_CASE("linear_elasticity-surface-3d", "[test_adjoint]")
@@ -233,7 +233,11 @@ TEST_CASE("topology-compliance", "[test_adjoint]")
 	std::shared_ptr<State> state_ptr = create_state_and_solve(in_args);
 	State &state = *state_ptr;
 
-	CompositeParametrization composite_map({std::make_shared<PowerMap>(5), std::make_shared<InsertConstantMap>(state.bases.size(), state.args["materials"]["nu"]), std::make_shared<ENu2LambdaMu>(state.mesh->is_volume())});
+	CompositeParametrization composite_map({
+		std::make_shared<PowerMap>(5), 
+		std::make_shared<InsertConstantMap>(state.bases.size(), state.args["materials"]["nu"]), 
+		std::make_shared<ENu2LambdaMu>(state.mesh->is_volume())
+	});
 
 	VariableToSimulationGroup variable_to_simulations;
 	variable_to_simulations.push_back(std::make_unique<ElasticVariableToSimulation>(state_ptr, composite_map));
@@ -249,7 +253,7 @@ TEST_CASE("topology-compliance", "[test_adjoint]")
 
 	Eigen::VectorXd x = variable_to_simulations[0]->inverse_eval();
 
-	verify_adjoint(*nl_problem, x, theta, 1e-4, 1e-2);
+	verify_adjoint(*nl_problem, x, theta, 1e-2, 1e-4);
 }
 
 #if defined(NDEBUG) && !defined(WIN32)

--- a/tests/test_diff.cpp
+++ b/tests/test_diff.cpp
@@ -44,7 +44,7 @@ namespace
 
 	std::shared_ptr<State> create_state_and_solve(const json &args)
 	{
-		std::shared_ptr<State> state = AdjointOptUtils::create_state(args);
+		std::shared_ptr<State> state = AdjointOptUtils::create_state(args, solver::CacheLevel::Derivatives, -1);
 		Eigen::MatrixXd sol, pressure;
 		state->solve_problem(sol, pressure);
 
@@ -732,7 +732,7 @@ TEST_CASE("node-trajectory", "[test_adjoint]")
 	const std::string path = POLYFEM_DATA_DIR + std::string("/differentiable/input/");
 	json in_args;
 	load_json(path + "node-trajectory.json", in_args);
-	auto state_ptr = AdjointOptUtils::create_state(in_args);
+	auto state_ptr = AdjointOptUtils::create_state(in_args, solver::CacheLevel::Derivatives, -1);
 	State &state = *state_ptr;
 
 	json opt_args;

--- a/tests/test_diff.cpp
+++ b/tests/test_diff.cpp
@@ -174,7 +174,7 @@ TEST_CASE("linear_elasticity-surface-3d", "[test_adjoint]")
 	variable_to_simulations.push_back(AdjointOptUtils::create_variable_to_simulation(opt_args["variable_to_simulation"][0], states, {}));
 
 	auto obj = std::make_shared<PositionForm>(variable_to_simulations, state, opt_args["functionals"][0]);
-	obj->set_integral_type(SpatialIntegralType::surface);
+	obj->set_integral_type(SpatialIntegralType::Surface);
 
 	auto nl_problem = std::make_shared<AdjointNLProblem>(obj, variable_to_simulations, states, opt_args);
 
@@ -206,7 +206,7 @@ TEST_CASE("linear_elasticity-surface", "[test_adjoint]")
 	variable_to_simulations.push_back(AdjointOptUtils::create_variable_to_simulation(opt_args["variable_to_simulation"][0], states, {}));
 
 	auto obj = std::make_shared<PositionForm>(variable_to_simulations, state, opt_args["functionals"][0]);
-	obj->set_integral_type(SpatialIntegralType::surface);
+	obj->set_integral_type(SpatialIntegralType::Surface);
 
 	auto nl_problem = std::make_shared<AdjointNLProblem>(obj, variable_to_simulations, states, opt_args);
 

--- a/tests/test_opt.cpp
+++ b/tests/test_opt.cpp
@@ -65,7 +65,7 @@ namespace
 		return true;
 	}
 
-	std::tuple<std::shared_ptr<AdjointForm>, std::vector<std::shared_ptr<VariableToSimulation>>, std::vector<std::shared_ptr<State>>> prepare_test(json &opt_args)
+	std::tuple<std::shared_ptr<AdjointForm>, std::vector<std::unique_ptr<VariableToSimulation>>, std::vector<std::shared_ptr<State>>> prepare_test(json &opt_args)
 	{
 		opt_args = AdjointOptUtils::apply_opt_json_spec(opt_args, false);
 
@@ -82,7 +82,7 @@ namespace
 		}
 
 		/* variable to simulations */
-		std::vector<std::shared_ptr<VariableToSimulation>> var2sim;
+		std::vector<std::unique_ptr<VariableToSimulation>> var2sim;
 		for (const auto &arg : opt_args["variable_to_simulation"])
 			var2sim.push_back(
 				AdjointOptUtils::create_variable_to_simulation(arg, states, variable_sizes));
@@ -91,7 +91,7 @@ namespace
 		std::shared_ptr<AdjointForm> obj = AdjointOptUtils::create_form(
 			opt_args["functionals"], var2sim, states);
 
-		return {obj, var2sim, states};
+		return {obj, std::move(var2sim), states};
 	}
 
 	// std::vector<double> read_energy(const std::string &file)
@@ -292,9 +292,9 @@ TEST_CASE("AMIPS-debug", "[optimization]")
 	Eigen::VectorXd x(2);
 	x << 0., 1.;
 
-	std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations;
+	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
 	{
-		variable_to_simulations.push_back(std::make_shared<ShapeVariableToSimulation>(states[0], CompositeParametrization()));
+		variable_to_simulations.push_back(std::make_unique<ShapeVariableToSimulation>(states[0], CompositeParametrization()));
 
 		VariableToBoundaryNodesExclusive variable_to_node(*states[0], {1});
 		variable_to_simulations[0]->set_output_indexing(variable_to_node.get_output_indexing());
@@ -419,12 +419,12 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	}
 // 	x.resize(opt_bnodes * dim);
 
-// 	std::vector<std::shared_ptr<VariableToSimulation>>
+// 	std::vector<std::unique_ptr<VariableToSimulation>>
 // 		variable_to_simulations;
 // 	{
 // 		std::vector<std::shared_ptr<Parametrization>> spline_boundary_map_list = {};
 
-// 		variable_to_simulations.push_back(std::make_shared<ShapeVariableToSimulation>(states[0], CompositeParametrization(spline_boundary_map_list)));
+// 		variable_to_simulations.push_back(std::make_unique<ShapeVariableToSimulation>(states[0], CompositeParametrization(spline_boundary_map_list)));
 // 		VariableToBoundaryNodes variable_to_node(*states[0], {4});
 // 		variable_to_simulations[0]->set_output_indexing(variable_to_node.get_output_indexing());
 // 	}
@@ -540,12 +540,12 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 		1,
 // 		1;
 
-// 	std::vector<std::shared_ptr<VariableToSimulation>>
+// 	std::vector<std::unique_ptr<VariableToSimulation>>
 // 		variable_to_simulations;
 // 	{
 // 		std::vector<std::shared_ptr<Parametrization>> spline_boundary_map_list = {std::make_shared<BSplineParametrization1DTo2D>(initial_control_points, knots, opt_bnodes, true)};
 
-// 		variable_to_simulations.push_back(std::make_shared<ShapeVariableToSimulation>(states[0], CompositeParametrization(spline_boundary_map_list)));
+// 		variable_to_simulations.push_back(std::make_unique<ShapeVariableToSimulation>(states[0], CompositeParametrization(spline_boundary_map_list)));
 
 // 		VariableToBoundaryNodes variable_to_node(*states[0], 4);
 // 		variable_to_simulations[0]->set_output_indexing(variable_to_node.get_output_indexing());
@@ -608,7 +608,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations;
+// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -781,7 +781,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations;
+// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -854,7 +854,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations;
+// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -925,7 +925,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::shared_ptr<VariableToSimulation>> variable_to_simulations;
+// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;

--- a/tests/test_opt.cpp
+++ b/tests/test_opt.cpp
@@ -65,7 +65,7 @@ namespace
 		return true;
 	}
 
-	std::tuple<std::shared_ptr<AdjointForm>, std::vector<std::unique_ptr<VariableToSimulation>>, std::vector<std::shared_ptr<State>>> prepare_test(json &opt_args)
+	std::tuple<std::shared_ptr<AdjointForm>, VariableToSimulationGroup, std::vector<std::shared_ptr<State>>> prepare_test(json &opt_args)
 	{
 		opt_args = AdjointOptUtils::apply_opt_json_spec(opt_args, false);
 
@@ -82,7 +82,7 @@ namespace
 		}
 
 		/* variable to simulations */
-		std::vector<std::unique_ptr<VariableToSimulation>> var2sim;
+		VariableToSimulationGroup var2sim;
 		for (const auto &arg : opt_args["variable_to_simulation"])
 			var2sim.push_back(
 				AdjointOptUtils::create_variable_to_simulation(arg, states, variable_sizes));
@@ -292,7 +292,7 @@ TEST_CASE("AMIPS-debug", "[optimization]")
 	Eigen::VectorXd x(2);
 	x << 0., 1.;
 
-	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
+	VariableToSimulationGroup variable_to_simulations;
 	{
 		variable_to_simulations.push_back(std::make_unique<ShapeVariableToSimulation>(states[0], CompositeParametrization()));
 
@@ -419,7 +419,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	}
 // 	x.resize(opt_bnodes * dim);
 
-// 	std::vector<std::unique_ptr<VariableToSimulation>>
+// 	VariableToSimulationGroup
 // 		variable_to_simulations;
 // 	{
 // 		std::vector<std::shared_ptr<Parametrization>> spline_boundary_map_list = {};
@@ -540,7 +540,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 		1,
 // 		1;
 
-// 	std::vector<std::unique_ptr<VariableToSimulation>>
+// 	VariableToSimulationGroup
 // 		variable_to_simulations;
 // 	{
 // 		std::vector<std::shared_ptr<Parametrization>> spline_boundary_map_list = {std::make_shared<BSplineParametrization1DTo2D>(initial_control_points, knots, opt_bnodes, true)};
@@ -608,7 +608,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
+// 	VariableToSimulationGroup variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -781,7 +781,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
+// 	VariableToSimulationGroup variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -854,7 +854,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
+// 	VariableToSimulationGroup variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;
@@ -925,7 +925,7 @@ TEST_CASE("shape-stress-opt", tagsopt)
 // 	std::shared_ptr<solver::AdjointNLProblem> nl_problem;
 // 	std::vector<std::shared_ptr<State>> states(state_args.size());
 // 	Eigen::VectorXd x;
-// 	std::vector<std::unique_ptr<VariableToSimulation>> variable_to_simulations;
+// 	VariableToSimulationGroup variable_to_simulations;
 // 	{
 // 		// create simulators based on json inputs
 // 		int i = 0;

--- a/tests/test_opt.cpp
+++ b/tests/test_opt.cpp
@@ -286,7 +286,7 @@ TEST_CASE("AMIPS-debug", "[optimization]")
 		if (!load_json(utils::resolve_path(args["path"], root_folder, false), cur_args))
 			log_and_throw_adjoint_error("Can't find json for State {}", i);
 
-		states[i++] = AdjointOptUtils::create_state(cur_args);
+		states[i++] = AdjointOptUtils::create_state(cur_args, solver::CacheLevel::Derivatives, -1);
 	}
 
 	Eigen::VectorXd x(2);


### PR DESCRIPTION
Main changes:

1. Wrap `std::vector<std::shared_ptr<VariableToSimulation>>` into a class and hide for loops over the vector inside.
2. Remove `first_derivative_unweighted` in `AdjointForm`, it may cause NAN if the weight is zero in the old version.
3. Move some implementations into cpp files.
4. Use struct instead of json to store data in IntegrableFunctional.
5. Make enum class naming consistent.
