### PR TITLE
Adds Recurrent Geometry and Random Rotation

### DIFF
--- a/json-specs/input-spec.json
+++ b/json-specs/input-spec.json
@@ -172,7 +172,9 @@
             "n_refs",
             "advanced",
             "enabled",
-            "is_obstacle"
+            "is_obstacle",
+            "each_time_step",
+            "random"
         ],
         "#type_name": "mesh",
         "doc": "Each geometry object stores a mesh, a set of transformations applied to it after loading, and a set of selections, which can be used to specify boundary conditions, materials, optimization parameters and other quantities that can be associated with a part of an object."
@@ -503,6 +505,53 @@
         "type": "bool",
         "default": false,
         "doc": "The geometry elements are not included in deforming geometry, only in collision computations"
+    },
+    {
+        "pointer": "/geometry/*/each_time_step",
+        "type": "int",
+        "default": 0,
+        "doc": "Adds a new geometry after a number of time steps"
+    },
+    {
+        "pointer": "/geometry/*/random",
+        "type": "object",
+        "optional": [
+            "rotation"
+        ],
+        "default": null,
+        "doc": "Generate random rotation for each new instance"
+    },
+    {
+        "pointer": "/geometry/*/random/rotation",
+        "type": "object",
+        "optional": [
+            "min",
+            "max"
+        ],
+        "default": null,
+        "doc": "Generate random rotation for each new instance"
+    },
+    {
+        "pointer": "/geometry/*/random/rotation/min",
+        "type": "list",
+        "default": [],
+        "doc": "Random minimal rotation"
+    },
+    {
+        "pointer": "/geometry/*/random/rotation/max",
+        "type": "list",
+        "default": [],
+        "doc": "Random max rotation"
+    },
+    {
+        "pointer": "/geometry/*/random/rotation/min/*",
+        "default": 0,
+        "type": "float"
+    },
+    {
+        "pointer": "/geometry/*/random/rotation/max/*",
+        "default": 0,
+        "type": "float"
     },
     {
         "pointer": "/geometry/*/enabled",

--- a/src/polyfem/State.cpp
+++ b/src/polyfem/State.cpp
@@ -1235,10 +1235,11 @@ namespace polyfem
 				const std::string root_path = utils::json_value<std::string>(args, "root_path", "");
 				// TODO: handle transformation per geometry
 				const json transformation = json_as_array(args["geometry"])[0]["transformation"];
+				const json random = json_as_array(args["geometry"])[0]["random"];
 				mesh::load_collision_proxy(
 					utils::resolve_path(collision_mesh_args["mesh"], root_path),
 					utils::resolve_path(collision_mesh_args["linear_map"], root_path),
-					in_node_to_node, transformation, collision_vertices, collision_codim_vids,
+					in_node_to_node, transformation, random, collision_vertices, collision_codim_vids,
 					collision_edges, collision_triangles, displacement_map_entries);
 			}
 			else

--- a/src/polyfem/State.hpp
+++ b/src/polyfem/State.hpp
@@ -161,6 +161,9 @@ namespace polyfem
 		std::vector<basis::ElementBases> pressure_bases;
 		/// Geometric mapping bases, if the elements are isoparametric, this list is empty
 		std::vector<basis::ElementBases> geom_bases_;
+		
+		/// recurrent geometry
+		std::vector<json> recurrent_geometry;
 
 		/// number of bases
 		int n_bases;
@@ -459,6 +462,12 @@ namespace polyfem
 			mesh = mesh::Mesh::create(V, F, non_conforming);
 			load_mesh(non_conforming);
 		}
+
+		/// loads the recurrent mesh from the json arguments
+		/// @param[in] time_step the current time step
+		/// @param[in] sol solution
+		/// @return True if the mesh has been updated
+		bool recurrent_mesh(int time_step, Eigen::MatrixXd &sol);
 
 		/// set the boundary sideset from a lambda that takes the face/edge barycenter
 		/// @param[in] boundary_marker function from face/edge barycenter that returns the sideset id

--- a/src/polyfem/mesh/GeometryReader.hpp
+++ b/src/polyfem/mesh/GeometryReader.hpp
@@ -34,10 +34,27 @@ namespace polyfem::mesh
 	std::unique_ptr<Mesh> read_fem_geometry(
 		const Units &units,
 		const json &geometry,
+		const json &args,
 		const std::string &root_path,
+		std::vector<json> &recurrent_geometry,
 		const std::vector<std::string> &names = std::vector<std::string>(),
 		const std::vector<Eigen::MatrixXd> &vertices = std::vector<Eigen::MatrixXd>(),
 		const std::vector<Eigen::MatrixXi> &cells = std::vector<Eigen::MatrixXi>(),
+		const bool non_conforming = false);
+	
+	///
+	/// @brief 		read a single FEM mesh from a geometry JSON
+	///
+	/// @param[in] geometry 		geometry JSON object
+	/// @param root_path 			root path of JSON
+	///
+	/// @return created Mesh object
+	///
+	void read_single_fem_geometry(
+		const Units &units,
+		const json &geometry,
+		const std::string &root_path,
+		std::unique_ptr<Mesh> &mesh,
 		const bool non_conforming = false);
 
 	///
@@ -93,6 +110,7 @@ namespace polyfem::mesh
 	void construct_affine_transformation(
 		const double unit_scale,
 		const json &transform,
+		const json &random,
 		const VectorNd &mesh_dimensions,
 		MatrixNd &A,
 		VectorNd &b);

--- a/src/polyfem/mesh/collision_proxy/CollisionProxy.cpp
+++ b/src/polyfem/mesh/collision_proxy/CollisionProxy.cpp
@@ -317,19 +317,21 @@ namespace polyfem::mesh
 		const std::string &weights_filename,
 		const Eigen::VectorXi &in_node_to_node,
 		const json &transformation,
+		const json &random,
 		Eigen::MatrixXd &vertices,
 		Eigen::VectorXi &codim_vertices,
 		Eigen::MatrixXi &edges,
 		Eigen::MatrixXi &faces,
 		std::vector<Eigen::Triplet<double>> &displacement_map_entries)
 	{
-		load_collision_proxy_mesh(mesh_filename, transformation, vertices, codim_vertices, edges, faces);
+		load_collision_proxy_mesh(mesh_filename, transformation, random, vertices, codim_vertices, edges, faces);
 		load_collision_proxy_displacement_map(weights_filename, in_node_to_node, vertices.rows(), displacement_map_entries);
 	}
 
 	void load_collision_proxy_mesh(
 		const std::string &mesh_filename,
 		const json &transformation,
+		const json &random,
 		Eigen::MatrixXd &vertices,
 		Eigen::VectorXi &codim_vertices,
 		Eigen::MatrixXi &edges,
@@ -352,7 +354,7 @@ namespace polyfem::mesh
 		VectorNd b;
 		// TODO: pass correct unit scale
 		construct_affine_transformation(
-			/*unit_scale=*/1, transformation,
+			/*unit_scale=*/1, transformation, random,
 			(bbox[1] - bbox[0]).cwiseAbs().transpose(),
 			A, b);
 		vertices = (vertices * A.transpose()).rowwise() + b.transpose();

--- a/src/polyfem/mesh/collision_proxy/CollisionProxy.hpp
+++ b/src/polyfem/mesh/collision_proxy/CollisionProxy.hpp
@@ -76,6 +76,7 @@ namespace polyfem::mesh
 		const std::string &weights_filename,
 		const Eigen::VectorXi &in_node_to_node,
 		const json &transformation,
+		const json &random,
 		Eigen::MatrixXd &vertices,
 		Eigen::VectorXi &codim_vertices,
 		Eigen::MatrixXi &edges,
@@ -92,6 +93,7 @@ namespace polyfem::mesh
 	void load_collision_proxy_mesh(
 		const std::string &mesh_filename,
 		const json &transformation,
+		const json &random,
 		Eigen::MatrixXd &vertices,
 		Eigen::VectorXi &codim_vertices,
 		Eigen::MatrixXi &edges,

--- a/src/polyfem/state/StateSolveLinear.cpp
+++ b/src/polyfem/state/StateSolveLinear.cpp
@@ -251,6 +251,8 @@ namespace polyfem
 		{
 			const double time = t0 + t * dt;
 
+			recurrent_mesh(t, sol);
+
 			StiffnessMatrix A;
 			Eigen::VectorXd b;
 			bool compute_spectrum = args["output"]["advanced"]["spectrum"];

--- a/src/polyfem/state/StateSolveNonlinear.cpp
+++ b/src/polyfem/state/StateSolveNonlinear.cpp
@@ -68,6 +68,8 @@ namespace polyfem
 				solve_tensor_nonlinear(sol, t);
 			}
 
+			recurrent_mesh(t, sol);
+
 #ifdef POLYFEM_WITH_REMESHING
 			if (remesh_enabled)
 			{


### PR DESCRIPTION
Adds an option to add new mesh after some time steps to feed new geometry in the simulation:
```json
{
    "mesh": "some_mesh.msh",
    "each_time_step": 10,
    "random": {
        "rotation": {
            "min": [-10, -30, 0],
            "max": [10, 30, 0]
        }
    }
}
```

In that example it adds a new object after each 10 time steps and in each new object it generates a new rotation between `[-10, -30, 0]` and `[10, 30, 0]`.

I only get trouble to make it work after restart a simulation. It calculates normal until reaches the first time step in which new mesh is added.