### PR TITLE
Docs improvements

### DIFF
--- a/docs/_doxygen/doxygen-awesome.css
+++ b/docs/_doxygen/doxygen-awesome.css
@@ -46,7 +46,7 @@ html {
     --border-radius-small: 4px;
     --border-radius-medium: 6px;
 
-    /* default spacings. Most compontest reference these values for spacing, to provide uniform spacing on the page. */
+    /* default spacings. Most components reference these values for spacing, to provide uniform spacing on the page. */
     --spacing-small: 5px;
     --spacing-medium: 10px;
     --spacing-large: 16px;

--- a/docs/main.md
+++ b/docs/main.md
@@ -18,13 +18,13 @@ The high-level functions of PolyFEM are in `polyfem::State`, a class containing 
 `polyfem::basis` contains the implementation of finite element basis functions.
 
 The module supports the following 2 dimensional elements:
-* Lagrangian triangular elements of degree 1 to 8 (`LagrangeBasis2d.hpp`)
+* Lagrangian triangular elements of degrees 1 to 8 (`LagrangeBasis2d.hpp`)
 * Lagrangian quadrilateral elements of degree 1 to 8 (`LagrangeBasis2d.hpp`)
 * Spline (IGA) elements of degree 1 to 4 (`SplineBasis2d.hpp`)
 * Polygonal elements (`PolygonalBasis2d.hpp`)
 
 The module supports the following 3 dimensional elements:
-* Lagrangian tetrahedral elements of degree 1 to 8 (`LagrangeBasis3d.hpp`)
+* Lagrangian tetrahedral elements of degrees 1 to 8 (`LagrangeBasis3d.hpp`)
 * Lagrangian hexahedral elements of degree 1 to 8 (`LagrangeBasis3d.hpp`)
 * Spline (IGA) elements of degree 1 to 4 (`SplineBasis3d.hpp`)
 * Polygonal elements (`PolygonalBasis3d.hpp`)
@@ -33,7 +33,7 @@ The module supports the following 3 dimensional elements:
 
 `polyfem::mesh` contains data structures and algorithms for simplicial and polygonal meshes.
 
-The interface is generic (`Mesh2D.hpp`, `Mesh3D.hpp`). There are two specializations: a conforming implementation which supports conforming polygonal meshes (`CMesh2D.hpp`, `CMesh3D.hpp`) without hanging nodes, and a non-conforming version (`CMesh2D.hpp`, `CMesh3D.hpp`) specialized for simplicial meshes only but supporting hanging nodes, which are used to implement adaptive h-refinement.
+The interface is generic (`Mesh2D.hpp`, `Mesh3D.hpp`). There are two specializations: a conforming implementation that supports conforming polygonal meshes (`CMesh2D.hpp`, `CMesh3D.hpp`) without hanging nodes, and a non-conforming version (`CMesh2D.hpp`, `CMesh3D.hpp`) specialized for simplicial meshes only but supporting hanging nodes, which are used to implement adaptive h-refinement.
 
 Many input formats are supported (see the JSON documentation for the complete list), and it outputs meshes in VTU (the format used by paraview/VTK).
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.