### PR TITLE
Remove stale AdjointTools.hpp include

### DIFF
--- a/src/polyfem/solver/forms/PressureForm.cpp
+++ b/src/polyfem/solver/forms/PressureForm.cpp
@@ -10,8 +10,6 @@
 
 #include <polyfem/autogen/auto_p_bases.hpp>
 
-#include <polyfem/optimization/AdjointTools.hpp>
-
 #include <polyfem/utils/Logger.hpp>
 
 namespace polyfem::solver


### PR DESCRIPTION

Closes #433

Remove stale `AdjointTools.hpp` include from `PressureForm.cpp`.
