### PR TITLE
Move basis-to-geometry mapping into DiffCache

### DIFF
--- a/src/polyfem/State.cpp
+++ b/src/polyfem/State.cpp
@@ -533,7 +533,6 @@ namespace polyfem
 		polys.clear();
 		poly_edge_to_data.clear();
 		rhs.resize(0, 0);
-		basis_nodes_to_gbasis_nodes.resize(0, 0);
 
 		if (assembler::MultiModel *mm = dynamic_cast<assembler::MultiModel *>(assembler.get()))
 		{
@@ -774,60 +773,6 @@ namespace polyfem
 
 		if (n_geom_bases == 0)
 			n_geom_bases = n_bases;
-
-		auto &gbases = geom_bases();
-
-		if (optimization_enabled == solver::CacheLevel::Derivatives)
-		{
-			std::map<std::array<int, 2>, double> pairs;
-			for (int e = 0; e < gbases.size(); e++)
-			{
-				const auto &gbs = gbases[e].bases;
-				const auto &bs = bases[e].bases;
-
-				Eigen::MatrixXd local_pts;
-				const int order = bs.front().order();
-				if (mesh->is_volume())
-				{
-					if (mesh->is_simplex(e))
-						autogen::p_nodes_3d(order, local_pts);
-					else
-						autogen::q_nodes_3d(order, local_pts);
-				}
-				else
-				{
-					if (mesh->is_simplex(e))
-						autogen::p_nodes_2d(order, local_pts);
-					else
-						autogen::q_nodes_2d(order, local_pts);
-				}
-
-				ElementAssemblyValues vals;
-				vals.compute(e, mesh->is_volume(), local_pts, gbases[e], gbases[e]);
-
-				for (int i = 0; i < bs.size(); i++)
-				{
-					for (int j = 0; j < gbs.size(); j++)
-					{
-						if (std::abs(vals.basis_values[j].val(i)) > 1e-7)
-						{
-							std::array<int, 2> index = {{gbs[j].global()[0].index, bs[i].global()[0].index}};
-							pairs.insert({index, vals.basis_values[j].val(i)});
-						}
-					}
-				}
-			}
-
-			const int dim = mesh->dimension();
-			std::vector<Eigen::Triplet<double>> coeffs;
-			coeffs.clear();
-			for (const auto &iter : pairs)
-				for (int d = 0; d < dim; d++)
-					coeffs.emplace_back(iter.first[0] * dim + d, iter.first[1] * dim + d, iter.second);
-
-			basis_nodes_to_gbasis_nodes.resize(n_geom_bases * mesh->dimension(), n_bases * mesh->dimension());
-			basis_nodes_to_gbasis_nodes.setFromTriplets(coeffs.begin(), coeffs.end());
-		}
 
 		for (const auto &lb : local_boundary)
 			total_local_boundary.emplace_back(lb);

--- a/src/polyfem/State.hpp
+++ b/src/polyfem/State.hpp
@@ -726,8 +726,6 @@ namespace polyfem
 
 		// to replace the initial condition in json during initial condition optimization
 		Eigen::MatrixXd initial_sol_update, initial_vel_update;
-		// mapping from positions of FE basis nodes to positions of geometry nodes
-		StiffnessMatrix basis_nodes_to_gbasis_nodes;
 
 		//---------------------------------------------------
 		//-----------------homogenization--------------------

--- a/src/polyfem/optimization/AdjointTools.cpp
+++ b/src/polyfem/optimization/AdjointTools.cpp
@@ -597,7 +597,7 @@ namespace polyfem::solver
 			if (state.solve_data.pressure_form)
 			{
 				PressureForceDerivative::force_shape_derivative(*state.solve_data.pressure_form, state.n_geom_bases, 0, sol, adjoint_zeroed, pressure_term);
-				pressure_term = state.basis_nodes_to_gbasis_nodes * pressure_term;
+				pressure_term = diff_cache.basis_nodes_to_gbasis_nodes() * pressure_term;
 			}
 			else
 				pressure_term.setZero(one_form.size());
@@ -613,7 +613,7 @@ namespace polyfem::solver
 					SmoothContactForceDerivative::force_shape_derivative(*smooth_contact, diff_cache.smooth_collision_set(0), sol, adjoint_zeroed, contact_term);
 				}
 
-				contact_term = state.basis_nodes_to_gbasis_nodes * contact_term;
+				contact_term = diff_cache.basis_nodes_to_gbasis_nodes() * contact_term;
 			}
 			else
 				contact_term.setZero(elasticity_term.size());
@@ -621,7 +621,7 @@ namespace polyfem::solver
 			if (state.is_adhesion_enabled())
 			{
 				NormalAdhesionForceDerivative::force_shape_derivative(*state.solve_data.normal_adhesion_form, diff_cache.normal_adhesion_collision_set(0), sol, adjoint, adhesion_term);
-				adhesion_term = state.basis_nodes_to_gbasis_nodes * adhesion_term;
+				adhesion_term = diff_cache.basis_nodes_to_gbasis_nodes() * adhesion_term;
 			}
 			else
 			{
@@ -664,7 +664,7 @@ namespace polyfem::solver
 				SmoothContactForceDerivative::force_shape_derivative(*smooth_contact, diff_cache.smooth_collision_set(0), sol, full_adjoint, contact_term);
 			}
 
-			contact_term = state.basis_nodes_to_gbasis_nodes * contact_term;
+			contact_term = diff_cache.basis_nodes_to_gbasis_nodes() * contact_term;
 		}
 		else
 			contact_term.setZero(elasticity_term.size());
@@ -672,7 +672,7 @@ namespace polyfem::solver
 		if (state.is_adhesion_enabled())
 		{
 			NormalAdhesionForceDerivative::force_shape_derivative(*state.solve_data.normal_adhesion_form, diff_cache.normal_adhesion_collision_set(0), sol, full_adjoint, adhesion_term);
-			adhesion_term = state.basis_nodes_to_gbasis_nodes * adhesion_term;
+			adhesion_term = diff_cache.basis_nodes_to_gbasis_nodes() * adhesion_term;
 		}
 		else
 		{
@@ -683,7 +683,7 @@ namespace polyfem::solver
 
 		Eigen::VectorXd force;
 		homo_problem->FullNLProblem::gradient(sol, force);
-		one_form -= state.basis_nodes_to_gbasis_nodes * utils::flatten(utils::unflatten(force, dim) * affine_adjoint);
+		one_form -= diff_cache.basis_nodes_to_gbasis_nodes() * utils::flatten(utils::unflatten(force, dim) * affine_adjoint);
 
 		one_form = utils::flatten(utils::unflatten(one_form, dim)(state.primitive_to_node(), Eigen::all));
 	}
@@ -715,7 +715,7 @@ namespace polyfem::solver
 		homo_problem->set_project_to_psd(false);
 		homo_problem->FullNLProblem::hessian(sol, hessian);
 		Eigen::VectorXd partial_term = full_adjoint.transpose() * hessian;
-		partial_term = state.basis_nodes_to_gbasis_nodes * utils::flatten(utils::unflatten(partial_term, dim) * diff_cache.disp_grad());
+		partial_term = diff_cache.basis_nodes_to_gbasis_nodes() * utils::flatten(utils::unflatten(partial_term, dim) * diff_cache.disp_grad());
 		one_form -= utils::flatten(utils::unflatten(partial_term, dim)(state.primitive_to_node(), Eigen::all));
 
 		one_form = periodic_mesh_map.apply_jacobian(one_form, periodic_mesh_representation);
@@ -723,7 +723,7 @@ namespace polyfem::solver
 		if (state.solve_data.periodic_contact_form)
 		{
 			Eigen::VectorXd contact_term;
-			PeriodicContactForceDerivative::force_shape_derivative(*state.solve_data.periodic_contact_form, state, periodic_mesh_map, periodic_mesh_representation, state.solve_data.periodic_contact_form->collision_set(), extended_sol, extended_adjoint, contact_term);
+			PeriodicContactForceDerivative::force_shape_derivative(*state.solve_data.periodic_contact_form, state, diff_cache, periodic_mesh_map, periodic_mesh_representation, state.solve_data.periodic_contact_form->collision_set(), extended_sol, extended_adjoint, contact_term);
 
 			one_form -= contact_term;
 		}
@@ -764,7 +764,7 @@ namespace polyfem::solver
 				ElasticForceDerivative::force_shape_derivative(*state.solve_data.elastic_form, t, state.n_geom_bases, diff_cache.u(i), diff_cache.u(i), cur_p, elasticity_term);
 				BodyForceDerivative::force_shape_derivative(*state.solve_data.body_form, state.n_geom_bases, t, diff_cache.u(i - 1), cur_p, rhs_term);
 				PressureForceDerivative::force_shape_derivative(*state.solve_data.pressure_form, state.n_geom_bases, t, diff_cache.u(i), cur_p, pressure_term);
-				pressure_term = state.basis_nodes_to_gbasis_nodes * pressure_term;
+				pressure_term = diff_cache.basis_nodes_to_gbasis_nodes() * pressure_term;
 
 				if (state.solve_data.damping_form)
 					ElasticForceDerivative::force_shape_derivative(*state.solve_data.damping_form, t, state.n_geom_bases, diff_cache.u(i), diff_cache.u(i - 1), cur_p, damping_term);
@@ -781,7 +781,7 @@ namespace polyfem::solver
 					{
 						SmoothContactForceDerivative::force_shape_derivative(*smooth_contact, diff_cache.smooth_collision_set(i), diff_cache.u(i), cur_p, contact_term);
 					}
-					contact_term = state.basis_nodes_to_gbasis_nodes * contact_term;
+					contact_term = diff_cache.basis_nodes_to_gbasis_nodes() * contact_term;
 					// contact_term /= beta_dt * beta_dt;
 				}
 				else
@@ -790,7 +790,7 @@ namespace polyfem::solver
 				if (state.solve_data.friction_form)
 				{
 					FrictionForceDerivative::force_shape_derivative(*state.solve_data.friction_form, diff_cache.u(i - 1), diff_cache.u(i), cur_p, diff_cache.friction_collision_set(i), friction_term);
-					friction_term = state.basis_nodes_to_gbasis_nodes * (friction_term / beta);
+					friction_term = diff_cache.basis_nodes_to_gbasis_nodes() * (friction_term / beta);
 					// friction_term /= beta_dt * beta_dt;
 				}
 				else
@@ -799,7 +799,7 @@ namespace polyfem::solver
 				if (state.is_adhesion_enabled())
 				{
 					NormalAdhesionForceDerivative::force_shape_derivative(*state.solve_data.normal_adhesion_form, diff_cache.normal_adhesion_collision_set(i), diff_cache.u(i), cur_p, adhesion_term);
-					adhesion_term = state.basis_nodes_to_gbasis_nodes * adhesion_term;
+					adhesion_term = diff_cache.basis_nodes_to_gbasis_nodes() * adhesion_term;
 				}
 				else
 				{
@@ -809,7 +809,7 @@ namespace polyfem::solver
 				if (state.solve_data.tangential_adhesion_form)
 				{
 					TangentialAdhesionForceDerivative::force_shape_derivative(*state.solve_data.tangential_adhesion_form, diff_cache.u(i - 1), diff_cache.u(i), cur_p, diff_cache.tangential_adhesion_collision_set(i), tangential_adhesion_term);
-					tangential_adhesion_term = state.basis_nodes_to_gbasis_nodes * (tangential_adhesion_term / beta);
+					tangential_adhesion_term = diff_cache.basis_nodes_to_gbasis_nodes() * (tangential_adhesion_term / beta);
 					// friction_term /= beta_dt * beta_dt;
 				}
 				else

--- a/src/polyfem/optimization/DiffCache.cpp
+++ b/src/polyfem/optimization/DiffCache.cpp
@@ -1,6 +1,11 @@
 #include <polyfem/optimization/DiffCache.hpp>
 
+#include <polyfem/assembler/ElementAssemblyValues.hpp>
+
 #include <polyfem/State.hpp>
+
+#include <polyfem/autogen/auto_p_bases.hpp>
+#include <polyfem/autogen/auto_q_bases.hpp>
 
 #include <polyfem/time_integrator/BDF.hpp>
 #include <polyfem/time_integrator/ImplicitEuler.hpp>
@@ -26,6 +31,9 @@
 
 #include <memory>
 #include <vector>
+#include <map>
+#include <array>
+#include <cmath>
 
 namespace polyfem
 {
@@ -102,6 +110,76 @@ namespace polyfem
 					}
 				}
 			}
+		}
+
+		StiffnessMatrix compute_basis_nodes_to_gbasis_nodes(const State &state)
+		{
+			auto &gbases = state.geom_bases();
+			auto &bases = state.bases;
+
+			std::map<std::array<int, 2>, double> pairs;
+			for (int e = 0; e < gbases.size(); e++)
+			{
+				auto &gbs = gbases[e].bases;
+				auto &bs = bases[e].bases;
+				assert(!bs.empty());
+
+				Eigen::MatrixXd local_pts;
+				int order = bs.front().order();
+				if (state.mesh->is_volume())
+				{
+					if (state.mesh->is_simplex(e))
+					{
+						autogen::p_nodes_3d(order, local_pts);
+					}
+					else
+					{
+						autogen::q_nodes_3d(order, local_pts);
+					}
+				}
+				else
+				{
+					if (state.mesh->is_simplex(e))
+					{
+						autogen::p_nodes_2d(order, local_pts);
+					}
+					else
+					{
+						autogen::q_nodes_2d(order, local_pts);
+					}
+				}
+
+				assembler::ElementAssemblyValues vals;
+				vals.compute(e, state.mesh->is_volume(), local_pts, gbases[e], gbases[e]);
+
+				for (int i = 0; i < bs.size(); i++)
+				{
+					for (int j = 0; j < gbs.size(); j++)
+					{
+						if (std::abs(vals.basis_values[j].val(i)) > 1e-7)
+						{
+							std::array<int, 2> index = {{gbs[j].global()[0].index, bs[i].global()[0].index}};
+							pairs.insert({index, vals.basis_values[j].val(i)});
+						}
+					}
+				}
+			}
+
+			int dim = state.mesh->dimension();
+			std::vector<Eigen::Triplet<double>> coeffs;
+			coeffs.reserve(pairs.size() * dim);
+			for (const auto &iter : pairs)
+			{
+				for (int d = 0; d < dim; d++)
+				{
+					coeffs.emplace_back(iter.first[0] * dim + d, iter.first[1] * dim + d, iter.second);
+				}
+			}
+
+			StiffnessMatrix mapping;
+			mapping.resize(state.n_geom_bases * dim, state.n_bases * dim);
+			mapping.setFromTriplets(coeffs.begin(), coeffs.end());
+			return mapping;
 		}
 	} // namespace
 
@@ -199,6 +277,14 @@ namespace polyfem
 
 	void DiffCache::cache_adjoints(const Eigen::MatrixXd &adjoint_mat) { adjoint_mat_ = adjoint_mat; }
 
+	const StiffnessMatrix &DiffCache::basis_nodes_to_gbasis_nodes() const
+	{
+		assert(basis_nodes_to_gbasis_nodes_.size() != 0
+			   && "basis_nodes_to_gbasis_nodes is empty. Expect cache_transient(step==0) to build it first.");
+
+		return basis_nodes_to_gbasis_nodes_;
+	}
+
 	void DiffCache::cache_transient(
 		int step,
 		State &state,
@@ -210,6 +296,11 @@ namespace polyfem
 		if (pressure)
 		{
 			log_and_throw_adjoint_error("Navier stoke problem is not supported in adjoint optimization.");
+		}
+
+		if (step == 0)
+		{
+			basis_nodes_to_gbasis_nodes_ = compute_basis_nodes_to_gbasis_nodes(s);
 		}
 
 		Eigen::MatrixXd disp_grad_final;

--- a/src/polyfem/optimization/DiffCache.hpp
+++ b/src/polyfem/optimization/DiffCache.hpp
@@ -40,6 +40,8 @@ namespace polyfem
 
 		const Eigen::MatrixXd &adjoint_mat() const { return adjoint_mat_; }
 
+		const StiffnessMatrix &basis_nodes_to_gbasis_nodes() const;
+
 		inline int size() const { return cur_size_; }
 		inline int bdf_order(int step) const
 		{
@@ -127,6 +129,9 @@ namespace polyfem
 	private:
 		int n_time_steps_ = 0;
 		int cur_size_ = 0;
+
+		// Mapping from positions of FE basis nodes to positions of geometry nodes.
+		StiffnessMatrix basis_nodes_to_gbasis_nodes_;
 
 		std::vector<Eigen::MatrixXd> disp_grad_; // macro linear displacement in homogenization
 		Eigen::MatrixXd u_;                      // PDE solution

--- a/src/polyfem/optimization/force_derivatives/PeriodicContactForceDerivative.cpp
+++ b/src/polyfem/optimization/force_derivatives/PeriodicContactForceDerivative.cpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include <polyfem/solver/forms/PeriodicContactForm.hpp>
 #include <polyfem/State.hpp>
+#include <polyfem/optimization/DiffCache.hpp>
 #include <polyfem/optimization/parametrization/PeriodicMeshToMesh.hpp>
 #include <polyfem/utils/MatrixUtils.hpp>
 #include <polyfem/utils/Types.hpp>
@@ -13,6 +14,7 @@ namespace polyfem::solver
 	void PeriodicContactForceDerivative::force_shape_derivative(
 		const PeriodicContactForm &form,
 		const State &state,
+		const DiffCache &diff_cache,
 		const PeriodicMeshToMesh &periodic_mesh_map,
 		const Eigen::VectorXd &periodic_mesh_representation,
 		const ipc::NormalCollisions &contact_set,
@@ -67,7 +69,8 @@ namespace polyfem::solver
 			unit_term.segment(k_full * dim, dim) += affine.transpose() * tiled_term.segment(k_full * dim, dim);
 		}
 
-		Eigen::VectorXd single_term = state.basis_nodes_to_gbasis_nodes * form.proj.topRows(dim * form.n_single_dof_) * unit_term;
+		Eigen::VectorXd single_term =
+			diff_cache.basis_nodes_to_gbasis_nodes() * form.proj.topRows(dim * form.n_single_dof_) * unit_term;
 		single_term = utils::flatten(utils::unflatten(single_term, dim)(state.primitive_to_node(), Eigen::all));
 
 		term.setZero(periodic_mesh_representation.size());

--- a/src/polyfem/optimization/force_derivatives/PeriodicContactForceDerivative.hpp
+++ b/src/polyfem/optimization/force_derivatives/PeriodicContactForceDerivative.hpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include <polyfem/solver/forms/PeriodicContactForm.hpp>
 #include <polyfem/State.hpp>
+#include <polyfem/optimization/DiffCache.hpp>
 #include <polyfem/optimization/parametrization/PeriodicMeshToMesh.hpp>
 #include <ipc/collisions/normal/normal_collisions.hpp>
 
@@ -14,6 +15,7 @@ namespace polyfem::solver
 		static void force_shape_derivative(
 			const PeriodicContactForm &form,
 			const State &state,
+			const DiffCache &diff_cache,
 			const PeriodicMeshToMesh &periodic_mesh_map,
 			const Eigen::VectorXd &periodic_mesh_representation,
 			const ipc::NormalCollisions &contact_set,

--- a/src/polyfem/optimization/forms/BarrierForms.cpp
+++ b/src/polyfem/optimization/forms/BarrierForms.cpp
@@ -495,7 +495,7 @@ namespace polyfem::solver
 			coeff(Eigen::seq(1, coeff.size(), collision_mesh_.dim())).array() = 1;
 			Eigen::VectorXd grads = (hessian * (coeff.array() * forces.array()).matrix());
 
-			grads = state_->basis_nodes_to_gbasis_nodes * grads;
+			grads = diff_cache_->basis_nodes_to_gbasis_nodes() * grads;
 			return AdjointTools::map_node_to_primitive_order(*state_, grads);
 		});
 	}

--- a/src/polyfem/optimization/forms/SpatialIntegralForms.cpp
+++ b/src/polyfem/optimization/forms/SpatialIntegralForms.cpp
@@ -29,6 +29,26 @@ namespace polyfem::solver
 
 		double dot(const Eigen::MatrixXd &A, const Eigen::MatrixXd &B) { return (A.array() * B.array()).sum(); }
 
+		Eigen::VectorXd reduced_to_full_shape_derivative(
+			const StiffnessMatrix &basis_nodes_to_gbasis_nodes,
+			const Eigen::MatrixXd &disp_grad,
+			const Eigen::VectorXd &adjoint_full,
+			const int n_bases,
+			const int dim)
+		{
+			assert(disp_grad.rows() == dim);
+			assert(disp_grad.cols() == dim);
+			assert(adjoint_full.size() == n_bases * dim);
+			assert(basis_nodes_to_gbasis_nodes.cols() == n_bases * dim);
+
+			Eigen::VectorXd term;
+			term.setZero(n_bases * dim);
+			for (int i = 0; i < n_bases; i++)
+				term.segment(i * dim, dim) += disp_grad.transpose() * adjoint_full.segment(i * dim, dim);
+
+			return basis_nodes_to_gbasis_nodes * term;
+		}
+
 		class LocalThreadScalarStorage
 		{
 		public:
@@ -77,8 +97,14 @@ namespace polyfem::solver
 			term *= this->weight();
 
 			const Eigen::VectorXd adjoint_rhs = this->compute_adjoint_rhs_step(time_step, x, *state_, *diff_cache_);
-			const NLHomoProblem &homo_problem = *std::dynamic_pointer_cast<NLHomoProblem>(state_->solve_data.nl_problem);
-			const Eigen::VectorXd full_shape_deriv = homo_problem.reduced_to_full_shape_derivative(diff_cache_->disp_grad(), adjoint_rhs);
+
+			const Eigen::VectorXd full_shape_deriv = reduced_to_full_shape_derivative(
+				diff_cache_->basis_nodes_to_gbasis_nodes(),
+				diff_cache_->disp_grad(),
+				adjoint_rhs,
+				state_->n_bases,
+				state_->mesh->dimension());
+
 			term += utils::flatten(utils::unflatten(full_shape_deriv, state_->mesh->dimension())(state_->primitive_to_node(), Eigen::all));
 
 			return term;

--- a/src/polyfem/optimization/forms/SurfaceTractionForms.cpp
+++ b/src/polyfem/optimization/forms/SurfaceTractionForms.cpp
@@ -1083,7 +1083,7 @@ namespace polyfem::solver
 			// logger().trace("fd norm {}", G.norm());
 			// logger().trace("grads difference norm {}", (G - grads).norm() / G.norm());
 
-			grads = state_->basis_nodes_to_gbasis_nodes * grads;
+			grads = diff_cache_->basis_nodes_to_gbasis_nodes() * grads;
 
 			return AdjointTools::map_node_to_primitive_order(*state_, grads);
 		});

--- a/src/polyfem/solver/NLHomoProblem.cpp
+++ b/src/polyfem/solver/NLHomoProblem.cpp
@@ -92,18 +92,6 @@ namespace polyfem::solver
 		return grad;
 	}
 
-	NLHomoProblem::TVector NLHomoProblem::reduced_to_full_shape_derivative(const Eigen::MatrixXd &disp_grad, const TVector &adjoint_full) const
-	{
-		const int dim = state_.mesh->dimension();
-
-		Eigen::VectorXd term;
-		term.setZero(state_.n_bases * dim);
-		for (int i = 0; i < state_.n_bases; i++)
-			term.segment(i * dim, dim) += disp_grad.transpose() * adjoint_full.segment(i * dim, dim);
-
-		return state_.basis_nodes_to_gbasis_nodes * term;
-	}
-
 	double NLHomoProblem::value(const TVector &x)
 	{
 		double val = FullNLProblem::value(reduced_to_full(x));

--- a/src/polyfem/solver/NLHomoProblem.hpp
+++ b/src/polyfem/solver/NLHomoProblem.hpp
@@ -42,7 +42,6 @@ namespace polyfem::solver
 		TVector full_to_reduced(const TVector &full) const;
 		TVector full_to_reduced_grad(const TVector &full) const override;
 		TVector reduced_to_full(const TVector &reduced) const;
-		TVector reduced_to_full_shape_derivative(const Eigen::MatrixXd &disp_grad, const TVector &adjoint_full) const;
 
 		TVector reduced_to_extended(const TVector &reduced, bool homogeneous = false) const;
 		TVector extended_to_reduced(const TVector &extended) const;


### PR DESCRIPTION
Closes #449 

- Remove `basis_nodes_to_gbasis_nodes` from State.
- Add cached `basis_nodes_to_gbasis_nodes` in DiffCache and update call sites.
- Extract NLHomoProblem `reduced_to_full_shape_derivative` as free function.
