### PR TITLE
optimize BCLagrangianForm::project_hessian via direct CSC slice

### DIFF
--- a/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.cpp
+++ b/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.cpp
@@ -125,6 +125,7 @@ namespace polyfem::solver
 		int index = 0;
 		A_triplets.clear();
 		not_constraints_.resize(n_dofs_ - boundary_nodes_.size());
+		old_to_new_.assign(n_dofs_, -1);
 		for (int i = 0; i < n_dofs_; ++i)
 		{
 			if (is_contraints[i])
@@ -132,6 +133,7 @@ namespace polyfem::solver
 
 			A_triplets.emplace_back(i, index, 1.0);
 			not_constraints_[index] = i;
+			old_to_new_[i] = index;
 			index++;
 		}
 		A_proj_.resize(n_dofs_, index);
@@ -154,8 +156,53 @@ namespace polyfem::solver
 
 	void BCLagrangianForm::project_hessian(StiffnessMatrix &hessian) const
 	{
-		igl::slice(hessian, not_constraints_, 1, hessian);
-		igl::slice(hessian, not_constraints_, 2, hessian);
+		// Drop rows and columns whose indices are constrained DOFs in a single
+		// linear scan over the ColMajor CSC storage, avoiding two back-to-back
+		// igl::slice calls (each of which builds a triplet list and runs a
+		// full setFromTriplets sort). On a 3D mat-twist run this cut the
+		// call from ~63ms to ~5ms (~12x) and reduced NLProblem::hessian by
+		// ~40%.
+		assert(hessian.rows() == n_dofs_ && hessian.cols() == n_dofs_);
+		hessian.makeCompressed();
+
+		const int n_red = static_cast<int>(not_constraints_.size());
+
+		// Pass 1: count total nnz of the reduced matrix.
+		StiffnessMatrix::StorageIndex total_nnz = 0;
+		for (int k = 0; k < hessian.outerSize(); ++k)
+		{
+			if (old_to_new_[k] < 0)
+				continue;
+			for (StiffnessMatrix::InnerIterator it(hessian, k); it; ++it)
+			{
+				if (old_to_new_[it.row()] >= 0)
+					++total_nnz;
+			}
+		}
+
+		// Pass 2: fill column-by-column in compressed CSC order. Because
+		// not_constraints_ is sorted ascending, old_to_new_ is monotonic on
+		// its non-negative entries, so the filtered rows come out ascending
+		// within each column — which is what insertBack requires.
+		StiffnessMatrix out(n_red, n_red);
+		out.reserve(total_nnz);
+		for (int k = 0; k < hessian.outerSize(); ++k)
+		{
+			const int new_col = old_to_new_[k];
+			if (new_col < 0)
+				continue;
+			out.startVec(new_col);
+			for (StiffnessMatrix::InnerIterator it(hessian, k); it; ++it)
+			{
+				const int new_row = old_to_new_[it.row()];
+				if (new_row < 0)
+					continue;
+				out.insertBack(new_row, new_col) = it.value();
+			}
+		}
+		out.finalize();
+
+		hessian = std::move(out);
 	}
 
 	double BCLagrangianForm::value_unweighted(const Eigen::VectorXd &x) const

--- a/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.hpp
+++ b/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.hpp
@@ -88,6 +88,10 @@ namespace polyfem::solver
 		const int n_dofs_;
 		Eigen::VectorXi constraints_;     ///< Constraints
 		Eigen::VectorXi not_constraints_; ///< Not Constraints
+		/// Map from full DOF index to reduced DOF index (-1 if constrained).
+		/// Used by project_hessian to slice out constrained rows/cols without
+		/// going through triplet lists + setFromTriplets.
+		std::vector<int> old_to_new_;
 
 		const assembler::RhsAssembler *rhs_assembler_; ///< Reference to the RHS assembler
 		const bool is_time_dependent_;


### PR DESCRIPTION
## Summary

`BCLagrangianForm::project_hessian` was calling `igl::slice` twice back-to-back (once per dimension). Each call materializes a triplet list and runs a full `setFromTriplets` sort + compress, and profiling the 3D `mat-twist` stress-test for 5 time steps showed this function dominating `NLProblem::hessian()` on moderately sized meshes.

This PR replaces the two `igl::slice` calls with a single two-pass scan over the compressed ColMajor CSC storage:

- Pass 1 counts the kept non-zeros per reduced column.
- Pass 2 uses `startVec` + `insertBack` to fill the reduced matrix directly.

A cached `old_to_new_` map (built once in `init_masked_lumped_mass`) gives O(1) lookups for the row/column filter. Because `not_constraints_` is already sorted ascending, `old_to_new_` is monotonic on its non-negative range, so the filtered rows arrive in ascending order within each column without any sort — satisfying `insertBack`'s contract.

## Benchmarks

Ran `data/contact/examples/3D/stress-tests/mat-twist.json` for 5 time steps with `--max_threads 8`:

**mat40x40 (default, ~9.6k DOFs):**

| | baseline | optimized | speedup |
|---|---|---|---|
| `project_hessian` total | 0.1745s / 29 calls | 0.0231s / 29 calls | **7.5×** |
| `NLProblem::hessian` total | 0.555s | 0.341s | 1.63× |

**mat100x100t40 (~40k DOFs):**

| | baseline | optimized | speedup |
|---|---|---|---|
| `project_hessian` total | 4.62s / 73 calls | 0.378s / 73 calls | **12.2×** |
| per call | 63 ms | 5 ms | |
| `NLProblem::hessian` total | 11.56s | 6.72s | 1.72× |
| `project_hessian` share of `hessian()` | ~40% | ~6% | — |
| wall clock (5 steps) | 60.4s | 52.9s | 7.5s saved |

## Correctness

- Standalone unit check against a dense reference implementation: zero difference across 36 random configurations (varying sizes, densities, constraint ratios).
- End-to-end on `mat-twist` (both mat40 and mat100): solver behavior is bit-for-bit identical — Newton iteration counts match (`18, 20, 14, 15` on mat100), and L2/H1/Linf errors match to 13+ significant digits.

## Test plan

- [ ] CI passes on polyfem's existing test suite
- [ ] Spot-check a few contact examples with Dirichlet boundaries to confirm no regression