### PR TITLE
experiment: disable obstacle rhs injection

### DIFF
--- a/src/polyfem/assembler/RhsAssembler.cpp
+++ b/src/polyfem/assembler/RhsAssembler.cpp
@@ -618,8 +618,6 @@ namespace polyfem
 					problem_.neumann_bc(mesh_, global_ids, uv, pts, normals, t, val);
 				},
 				local_boundary, bounday_nodes, resolution, local_neumann_boundary, displacement, t, rhs);
-
-			obstacle_.update_displacement(t, rhs);
 		}
 
 		void RhsAssembler::compute_energy_grad(const std::vector<LocalBoundary> &local_boundary, const std::vector<int> &bounday_nodes, const Density &density, const int resolution, const std::vector<LocalBoundary> &local_neumann_boundary, const Eigen::MatrixXd &final_rhs, const double t, Eigen::MatrixXd &rhs) const

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(test_sources
   test_matrix.cpp
   test_ncmesh.cpp
   test_normal.cpp
+  test_obstacle.cpp
   test_output.cpp
   test_parametrizations.cpp
   test_periodic.cpp

--- a/tests/test_obstacle.cpp
+++ b/tests/test_obstacle.cpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+#include <catch2/catch_test_macros.hpp>
+
+#include <polyfem/State.hpp>
+
+////////////////////////////////////////////////////////////////////////////////
+
+using namespace polyfem;
+
+TEST_CASE("obstacle displacement is not injected into rhs through set_bc", "[obstacle]")
+{
+	json in_args = R"(
+		{
+			"materials": {
+				"type": "LinearElasticity",
+				"E": 1000,
+				"nu": 0.3,
+				"rho": 1000
+			},
+			"geometry": [{
+				"mesh": "",
+				"type": "mesh",
+				"enabled": true
+			}, {
+				"mesh": "",
+				"type": "mesh",
+				"enabled": true,
+				"is_obstacle": true,
+				"surface_selection": 1,
+				"transformation": {
+					"translation": [0.0, 1.25]
+				}
+			}],
+			"space": {
+				"discr_order": 1,
+				"advanced": {
+					"bc_method": "sample"
+				}
+			},
+			"boundary_conditions": {
+				"rhs": [0, 0],
+				"obstacle_displacements": [{
+					"id": 1,
+					"value": [0.25, -0.5]
+				}]
+			},
+			"solver": {
+				"linear": {
+					"solver": "Eigen::SimplicialLDLT"
+				}
+			}
+		})"_json;
+
+	in_args["geometry"][0]["mesh"] =
+		std::string(POLYFEM_DATA_DIR) + "/contact/meshes/2D/simple/square.obj";
+	in_args["geometry"][1]["mesh"] =
+		std::string(POLYFEM_DATA_DIR) + "/contact/meshes/2D/simple/square.obj";
+
+	State state;
+	state.set_max_threads(1);
+	state.init_logger("", spdlog::level::off, spdlog::level::off, false);
+	state.init(in_args, true);
+	state.load_mesh(true);
+	state.build_basis();
+	state.assemble_rhs();
+
+	REQUIRE(state.solve_data.rhs_assembler != nullptr);
+	REQUIRE(state.obstacle.n_vertices() > 0);
+
+	Eigen::MatrixXd rhs = state.rhs;
+	const Eigen::MatrixXd rhs_before = rhs;
+
+	state.solve_data.rhs_assembler->set_bc(
+		state.local_boundary,
+		state.boundary_nodes,
+		state.n_boundary_samples(),
+		state.local_neumann_boundary,
+		rhs,
+		Eigen::MatrixXd(),
+		0.5);
+
+	REQUIRE(rhs.rows() >= state.obstacle.ndof());
+	const Eigen::MatrixXd obstacle_rows_after = rhs.bottomRows(state.obstacle.ndof());
+	const Eigen::MatrixXd obstacle_rows_before = rhs_before.bottomRows(state.obstacle.ndof());
+	REQUIRE((obstacle_rows_after - obstacle_rows_before).cwiseAbs().maxCoeff() == 0.0);
+}


### PR DESCRIPTION
## Summary
- stop injecting obstacle_displacements into the rhs inside RhsAssembler::set_bc()
- add a small integration test that checks set_bc() no longer overwrites the obstacle rows at the bottom of the rhs vector

## Verification
- attempted cmake --build build --target unit_tests PolyFEM_bin, but the updated upstream main build is currently blocked in dependency fetching (mkl-include via CPM) in this environment
- attempted cmake -S . -B build_codex -DCMAKE_BUILD_TYPE=Release with a fresh CPM cache, but configure is still in dependency fetching and has not completed yet
- ran cpplint on the touched files; RhsAssembler.cpp reports many pre-existing style violations in upstream PolyFEM, and the new test file would need project-specific style cleanup once the build path is stable

## Notes
- this is an experiment branch intended to isolate whether obstacle displacement rhs injection materially affects the nonlinear solve behavior for the masticator scene
