### PR TITLE
Make adhesion output optional

### DIFF
--- a/src/polyfem/io/OutData.cpp
+++ b/src/polyfem/io/OutData.cpp
@@ -2421,14 +2421,21 @@ namespace polyfem::io
 			writer.add_field("friction_forces", forces_reshaped);
 		}
 
-		ipc::NormalCollisions adhesion_collision_set;
-		adhesion_collision_set.build(
-			collision_mesh, displaced_surface, dhat_a,
-			/*dmin=*/0, ipc::create_broad_phase(state.args["solver"]["contact"]["CCD"]["broad_phase"]).get());
+		const bool adhesion_enabled = state.is_adhesion_enabled();
+		const bool need_normal_adhesion = adhesion_enabled && (opts.normal_adhesion_forces || opts.export_field("normal_adhesion_forces"));
+		const bool need_tangential_adhesion = adhesion_enabled && (opts.tangential_adhesion_forces || opts.export_field("tangential_adhesion_forces"));
 
+		ipc::NormalCollisions adhesion_collision_set;
 		ipc::NormalAdhesionPotential normal_adhesion_potential(dhat_p, dhat_a, Y, 1);
 
-		if (opts.normal_adhesion_forces || opts.export_field("normal_adhesion_forces"))
+		if (need_normal_adhesion || need_tangential_adhesion)
+		{
+			adhesion_collision_set.build(
+				collision_mesh, displaced_surface, dhat_a,
+				/*dmin=*/0, ipc::create_broad_phase(state.args["solver"]["contact"]["CCD"]["broad_phase"]).get());
+		}
+
+		if (need_normal_adhesion)
 		{
 			Eigen::MatrixXd forces = -1 * normal_adhesion_potential.gradient(adhesion_collision_set, collision_mesh, displaced_surface);
 
@@ -2439,7 +2446,7 @@ namespace polyfem::io
 			writer.add_field("normal_adhesion_forces", forces_reshaped);
 		}
 
-		if (opts.tangential_adhesion_forces || opts.export_field("tangential_adhesion_forces"))
+		if (need_tangential_adhesion)
 		{
 			ipc::TangentialCollisions tangential_collision_set;
 			tangential_collision_set.build(

--- a/src/polyfem/mesh/remesh/wild_remesh/LocalRelaxationData.cpp
+++ b/src/polyfem/mesh/remesh/wild_remesh/LocalRelaxationData.cpp
@@ -292,7 +292,7 @@ namespace polyfem::mesh
 				state.args["contact"]["use_adaptive_dhat"],
 				state.args["contact"]["min_distance_ratio"],
 				// Normal Adhesion Form
-				state.args["contact"]["adhesion"]["adhesion_enabled"],
+				state.is_adhesion_enabled(),
 				state.args["contact"]["adhesion"]["dhat_p"],
 				state.args["contact"]["adhesion"]["dhat_a"],
 				state.args["contact"]["adhesion"]["adhesion_strength"],

--- a/src/polyfem/state/StateHomogenization.cpp
+++ b/src/polyfem/state/StateHomogenization.cpp
@@ -80,7 +80,7 @@ namespace polyfem
 			args["contact"]["use_adaptive_dhat"],
 			args["contact"]["min_distance_ratio"],
 			// Normal Adhesion Form
-			args["contact"]["adhesion"]["adhesion_enabled"],
+			is_adhesion_enabled(),
 			args["contact"]["adhesion"]["dhat_p"],
 			args["contact"]["adhesion"]["dhat_a"],
 			args["contact"]["adhesion"]["adhesion_strength"],

--- a/src/polyfem/state/StateSolveNonlinear.cpp
+++ b/src/polyfem/state/StateSolveNonlinear.cpp
@@ -296,7 +296,7 @@ namespace polyfem
 			args["contact"]["use_adaptive_dhat"],
 			args["contact"]["min_distance_ratio"],
 			// Normal Adhesion Form
-			args["contact"]["adhesion"]["adhesion_enabled"],
+			is_adhesion_enabled(),
 			args["contact"]["adhesion"]["dhat_p"],
 			args["contact"]["adhesion"]["dhat_a"],
 			args["contact"]["adhesion"]["adhesion_strength"],


### PR DESCRIPTION
## Summary
- Skip building `adhesion_collision_set` in `OutData.cpp` unless normal or tangential adhesion forces are actually requested for export.
- Additionally gate both adhesion exports on `state.is_adhesion_enabled()` so nothing is computed when adhesion is disabled.
- Replace remaining direct `args["contact"]["adhesion"]["adhesion_enabled"]` reads with `is_adhesion_enabled()` in `StateHomogenization.cpp`, `StateSolveNonlinear.cpp`, and `LocalRelaxationData.cpp`.

## Test plan
- [ ] Build polyfem and run an existing contact simulation without adhesion; confirm no adhesion-related work is done during VTU export.
- [ ] Run a simulation with adhesion enabled and `normal_adhesion_forces` / `tangential_adhesion_forces` toggled; confirm fields appear only when requested.