### PR TITLE
Adding back and merging updates from the previous PR on fiber_bug

### DIFF
--- a/src/polyfem/assembler/HGOFiber.hpp
+++ b/src/polyfem/assembler/HGOFiber.hpp
@@ -23,15 +23,16 @@ namespace polyfem::assembler
 			const int el_id,
 			const DefGradMatrix<T> &def_grad) const
 		{
-			const double k1 = k1_(p, t, el_id);
-			const double k2 = k2_(p, t, el_id);
 			const T i4Bar = I4Bar(p, t, el_id, def_grad);
 
+			// Fiber only contributes in tension (I4 > 1 means stretched)
 			if (i4Bar <= T(1.0))
 				return T(0.0);
 
+			const double k1 = k1_(p, t, el_id);
+			const double k2 = k2_(p, t, el_id);
 			const T temp = i4Bar - T(1.0);
-
+			
 			return (k1 / (2.0 * k2)) * (exp(k2 * temp * temp) - 1.0);
 		}
 

--- a/src/polyfem/assembler/SumModel.hpp
+++ b/src/polyfem/assembler/SumModel.hpp
@@ -31,6 +31,12 @@ namespace polyfem::assembler
 		bool allow_inversion() const override { return true; }
 		std::map<std::string, ParamFunc> parameters() const override;
 
+		void assign_stress_tensor_per_component(const OutputData &data,
+												 const int all_size,
+												 const ElasticityTensorType &type,
+												 std::vector<std::pair<std::string, Eigen::MatrixXd>> &all,
+												 const std::function<Eigen::MatrixXd(const Eigen::MatrixXd &)> &fun) const;
+
 	protected:
 		void assign_stress_tensor(const OutputData &data,
 								  const int all_size,

--- a/src/polyfem/io/Evaluator.cpp
+++ b/src/polyfem/io/Evaluator.cpp
@@ -12,11 +12,14 @@
 
 #include <polyfem/utils/BoundarySampler.hpp>
 #include <polyfem/utils/Jacobian.hpp>
+#include <polyfem/utils/ElasticityUtils.hpp>
 
 #include <polyfem/autogen/auto_p_bases.hpp>
 #include <polyfem/autogen/auto_q_bases.hpp>
 #include <polyfem/autogen/prism_bases.hpp>
 #include <polyfem/autogen/auto_pyramid_bases.hpp>
+
+#include <polyfem/assembler/SumModel.hpp>
 
 #include <polyfem/utils/Logger.hpp>
 
@@ -1097,6 +1100,137 @@ namespace polyfem::io
 		const Eigen::MatrixXd &grad)
 	{
 		return utils::flatten(get_bases_position(n_bases, mesh_nodes) * grad.transpose());
+	}
+
+	void Evaluator::compute_tensor_value_per_component(
+		const mesh::Mesh &mesh,
+		const bool is_problem_scalar,
+		const std::vector<basis::ElementBases> &bases,
+		const std::vector<basis::ElementBases> &gbases,
+		const Eigen::VectorXi &disc_orders,
+		const std::map<int, Eigen::MatrixXd> &polys,
+		const std::map<int, std::pair<Eigen::MatrixXd, Eigen::MatrixXi>> &polys_3d,
+		const assembler::Assembler &assembler,
+		const utils::RefElementSampler &sampler,
+		const int n_points,
+		const Eigen::MatrixXd &fun,
+		const double t,
+		std::vector<assembler::Assembler::NamedMatrix> &result,
+		const bool use_sampler,
+		const bool boundary_only)
+	{
+		logger().info("compute_tensor_value_per_component CALLED with assembler type: {}", assembler.name());
+		
+		if (fun.size() <= 0)
+		{
+			logger().error("Solve the problem first!");
+			return;
+		}
+
+		result.clear();
+
+		const int actual_dim = mesh.dimension();
+		assert(!is_problem_scalar);
+
+		// Try to cast directly to SumModel
+		const auto *sum_model = dynamic_cast<const assembler::SumModel *>(&assembler);
+		if (!sum_model)
+		{
+			// Not a SumModel, silently return (no per-component data available)
+			logger().debug("Assembler is not a SumModel (type: {}), skipping per-component export", assembler.name());
+			return;
+		}
+
+		logger().info("Exporting individual stress components from SumModel");
+
+		int index = 0;
+
+		Eigen::MatrixXi vis_faces_poly, vis_edges_poly;
+		std::vector<std::pair<std::string, Eigen::MatrixXd>> tmp_components;
+
+		for (int i = 0; i < int(bases.size()); ++i)
+		{
+			if (boundary_only && mesh.is_volume() && !mesh.is_boundary_element(i))
+				continue;
+
+			const ElementBases &bs = bases[i];
+			const ElementBases &gbs = gbases[i];
+			Eigen::MatrixXd local_pts;
+
+			if (use_sampler)
+			{
+				if (mesh.is_simplex(i))
+					local_pts = sampler.simplex_points();
+				else if (mesh.is_cube(i))
+					local_pts = sampler.cube_points();
+				else
+				{
+					if (mesh.is_volume())
+						sampler.sample_polyhedron(polys_3d.at(i).first, polys_3d.at(i).second, local_pts, vis_faces_poly, vis_edges_poly);
+					else
+						sampler.sample_polygon(polys.at(i), local_pts, vis_faces_poly, vis_edges_poly);
+				}
+			}
+			else
+			{
+				if (mesh.is_volume())
+				{
+					if (mesh.is_simplex(i))
+						autogen::p_nodes_3d(disc_orders(i), local_pts);
+					else if (mesh.is_cube(i))
+						autogen::q_nodes_3d(disc_orders(i), local_pts);
+					else
+						continue;
+				}
+				else
+				{
+					if (mesh.is_simplex(i))
+						autogen::p_nodes_2d(disc_orders(i), local_pts);
+					else if (mesh.is_cube(i))
+						autogen::q_nodes_2d(disc_orders(i), local_pts);
+					else
+						continue;
+				}
+			}
+
+			// Call SumModel's per-component stress method
+			sum_model->assign_stress_tensor_per_component(
+				assembler::OutputData(t, i, bs, gbs, local_pts, fun),
+				actual_dim * actual_dim,
+				ElasticityTensorType::CAUCHY,
+				tmp_components,
+				[](const Eigen::MatrixXd &S) -> Eigen::MatrixXd
+				{
+					// Flatten 3x3 tensor to row vector [S11, S12, S13, S21, S22, S23, S31, S32, S33]
+					Eigen::MatrixXd flattened(1, S.size());
+					int idx = 0;
+					for (int i = 0; i < S.rows(); ++i)
+						for (int j = 0; j < S.cols(); ++j)
+							flattened(0, idx++) = S(i, j);
+					return flattened;
+				});
+
+			// Initialize result structure on first element
+			if (result.empty())
+			{
+				result.resize(tmp_components.size());
+				for (int k = 0; k < tmp_components.size(); ++k)
+				{
+					result[k].first = tmp_components[k].first;
+					result[k].second.resize(n_points, actual_dim * actual_dim);
+				}
+			}
+
+			// Accumulate component stresses
+			for (int k = 0; k < tmp_components.size(); ++k)
+			{
+				assert(local_pts.rows() == tmp_components[k].second.rows());
+				result[k].second.block(index, 0, tmp_components[k].second.rows(), tmp_components[k].second.cols()) =
+					tmp_components[k].second;
+			}
+
+			index += local_pts.rows();
+		}
 	}
 
 	Eigen::VectorXd Evaluator::integrate_function(

--- a/src/polyfem/io/Evaluator.hpp
+++ b/src/polyfem/io/Evaluator.hpp
@@ -304,6 +304,24 @@ namespace polyfem::io
 			const bool use_sampler,
 			const bool boundary_only);
 
+		/// computes tensor quantities per material component (for SumModel/MaterialSum only)
+		static void compute_tensor_value_per_component(
+			const mesh::Mesh &mesh,
+			const bool is_problem_scalar,
+			const std::vector<basis::ElementBases> &bases,
+			const std::vector<basis::ElementBases> &gbases,
+			const Eigen::VectorXi &disc_orders,
+			const std::map<int, Eigen::MatrixXd> &polys,
+			const std::map<int, std::pair<Eigen::MatrixXd, Eigen::MatrixXi>> &polys_3d,
+			const assembler::Assembler &assembler,
+			const utils::RefElementSampler &sampler,
+			const int n_points,
+			const Eigen::MatrixXd &fun,
+			const double t,
+			std::vector<assembler::Assembler::NamedMatrix> &result,
+			const bool use_sampler,
+			const bool boundary_only);
+
 		/// computes integrated solution (fun) per surface face. pts and faces are the boundary are the boundary on the rest configuration
 		/// @param[in] mesh mesh
 		/// @param[in] is_problem_scalar if problem is scalar

--- a/src/polyfem/io/OutData.cpp
+++ b/src/polyfem/io/OutData.cpp
@@ -1739,6 +1739,20 @@ namespace polyfem::io
 					state.polys, state.polys_3d, *state.assembler, ref_element_sampler,
 					points.rows(), sol, t, tvals, opts.use_sampler, opts.boundary_only);
 
+				// Also get per-component stresses (for SumModel only)
+				logger().info("About to call compute_tensor_value_per_component with assembler: {}", state.assembler->name());
+				std::vector<assembler::Assembler::NamedMatrix> component_tvals;
+				Evaluator::compute_tensor_value_per_component(
+					mesh, problem.is_scalar(), bases, gbases, state.disc_orders,
+					state.polys, state.polys_3d, *state.assembler, ref_element_sampler,
+					points.rows(), sol, t, component_tvals, opts.use_sampler, opts.boundary_only);
+
+				logger().info("compute_tensor_value_per_component returned {} components", component_tvals.size());
+				
+				// Append component stresses to tvals
+				for (const auto &component : component_tvals)
+					tvals.push_back(component);
+
 				for (auto &[_, v] : tvals)
 					utils::append_rows_of_zeros(v, obstacle.n_vertices());
 


### PR DESCRIPTION
@teseoch @danielepanozzo. Here is my resubmission of #424 per your request, rebased onto current main.
This PR makes two changes:

1. **Output per-component stress tensors**. This Adds functionality to output 
   individual stress tensor components through the Evaluator/OutData pipeline.
   (Touches: SumModel, Evaluator, OutData)

2. **Fix typo in SumModel.cpp** . This Corrects `assembler_.front()` to 
   `assemblers_.front()` in `assign_stress_tensor`.

The original "added compression" commit is no longer needed since upstream 
already implements the tension-only check in `HGOFiber.hpp`; only the 
`SumModel.cpp` fix from that commit remains.

## Testing
- Built locally on macOS (Apple Silicon) with Apple Clang 17.0 and CMake 4.1.
- Ran a simulation with "MaterialSum" and worked as expected.

Thank you! Lmk if you have any questions.