### PR TITLE
Amips power from json

### DIFF
--- a/json-specs/material-parameters.json
+++ b/json-specs/material-parameters.json
@@ -756,10 +756,11 @@
         "type": "float",
         "default": 1.0,
         "doc": "Scale factor for the AMIPS energy."
-    },{
+    },
+    {
     "pointer": "/power",
     "type": "float",
     "default": 1.0,
     "doc": "Power exponent applied to the energy functional"
-}
+    }
 ]

--- a/json-specs/material-parameters.json
+++ b/json-specs/material-parameters.json
@@ -444,6 +444,7 @@
         "optional": [
             "use_rest_pose",
             "weight",
+            "power",
             "id",
             "rho"
         ],
@@ -755,5 +756,10 @@
         "type": "float",
         "default": 1.0,
         "doc": "Scale factor for the AMIPS energy."
-    }
+    },{
+    "pointer": "/power",
+    "type": "float",
+    "default": 1.0,
+    "doc": "Power exponent applied to the energy functional"
+}
 ]

--- a/src/polyfem/assembler/AMIPSEnergy.cpp
+++ b/src/polyfem/assembler/AMIPSEnergy.cpp
@@ -25,6 +25,7 @@ namespace polyfem::assembler
 			energy_weights_[index] = params["weight"].get<double>();
 		else
 			energy_weights_[index] = 1.0;
+		read_power(index, params);  
 	}
 
 	double AMIPSEnergy::get_energy_weight(const int el_id) const

--- a/src/polyfem/assembler/AMIPSEnergy.cpp
+++ b/src/polyfem/assembler/AMIPSEnergy.cpp
@@ -25,7 +25,8 @@ namespace polyfem::assembler
 			energy_weights_[index] = params["weight"].get<double>();
 		else
 			energy_weights_[index] = 1.0;
-		read_power(index, params);  
+		//read_power(index, params);
+		power_.add_multimaterial(index, params, "", root_path);
 	}
 
 	double AMIPSEnergy::get_energy_weight(const int el_id) const

--- a/src/polyfem/assembler/AMIPSEnergy.hpp
+++ b/src/polyfem/assembler/AMIPSEnergy.hpp
@@ -66,7 +66,10 @@ namespace polyfem::assembler
 
 			const T powJ = pow(det, power);
 			const double weight = get_energy_weight(el_id);
-			return T(weight) * (def_grad.transpose() * def_grad).trace() / powJ; //+ barrier<T>::value(det);
+			const T base_energy = (def_grad.transpose() * def_grad).trace() / powJ;
+			return T(weight) * pow(base_energy, get_power(el_id));
+			//return T(weight) * (def_grad.transpose() * def_grad).trace() / powJ; //+ barrier<T>::value(det);
+			
 		}
 
 	private:
@@ -104,6 +107,29 @@ namespace polyfem::assembler
 			}
 
 			return res;
+		}
+
+
+
+
+		std::vector<double> power_values_;
+
+		void read_power(const int index, const json &params)
+		{
+			if (power_values_.size() <= index)
+				power_values_.resize(index + 1, 1.0);
+			if (params.contains("power"))
+				power_values_[index] = params["power"].get<double>();
+			else
+				power_values_[index] = 1.0;
+		}
+
+		double get_power(const int el_id) const
+		{
+			if (power_values_.empty()) return 1.0;
+			if (power_values_.size() == 1) return power_values_[0];
+			if (el_id >= 0 && el_id < (int)power_values_.size()) return power_values_[el_id];
+			return 1.0;
 		}
 
 	public:

--- a/src/polyfem/assembler/AMIPSEnergy.hpp
+++ b/src/polyfem/assembler/AMIPSEnergy.hpp
@@ -67,7 +67,9 @@ namespace polyfem::assembler
 			const T powJ = pow(det, power);
 			const double weight = get_energy_weight(el_id);
 			const T base_energy = (def_grad.transpose() * def_grad).trace() / powJ;
-			return T(weight) * pow(base_energy, get_power(el_id));
+
+			const double power = power_[el_id](p, t, el_id);
+			return T(weight) * pow(base_energy, power);
 			//return T(weight) * (def_grad.transpose() * def_grad).trace() / powJ; //+ barrier<T>::value(det);
 			
 		}
@@ -113,6 +115,7 @@ namespace polyfem::assembler
 
 
 		std::vector<double> power_values_;
+		GenericMatParams power_;
 
 		void read_power(const int index, const json &params)
 		{

--- a/src/polyfem/assembler/AMIPSEnergy.hpp
+++ b/src/polyfem/assembler/AMIPSEnergy.hpp
@@ -68,8 +68,7 @@ namespace polyfem::assembler
 			const double weight = get_energy_weight(el_id);
 			const T base_energy = (def_grad.transpose() * def_grad).trace() / powJ;
 
-			const double power = power_[el_id](p, t, el_id);
-			return T(weight) * pow(base_energy, power);
+			return T(weight) * pow(base_energy, power_[el_id](p, t, el_id));
 			//return T(weight) * (def_grad.transpose() * def_grad).trace() / powJ; //+ barrier<T>::value(det);
 			
 		}
@@ -114,26 +113,8 @@ namespace polyfem::assembler
 
 
 
-		std::vector<double> power_values_;
-		GenericMatParams power_;
-
-		void read_power(const int index, const json &params)
-		{
-			if (power_values_.size() <= index)
-				power_values_.resize(index + 1, 1.0);
-			if (params.contains("power"))
-				power_values_[index] = params["power"].get<double>();
-			else
-				power_values_[index] = 1.0;
-		}
-
-		double get_power(const int el_id) const
-		{
-			if (power_values_.empty()) return 1.0;
-			if (power_values_.size() == 1) return power_values_[0];
-			if (el_id >= 0 && el_id < (int)power_values_.size()) return power_values_[el_id];
-			return 1.0;
-		}
+		GenericMatParams power_{"power"};
+	
 
 	public:
 		Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 3, 3> gradient(

--- a/src/polyfem/assembler/GenericElastic.hpp
+++ b/src/polyfem/assembler/GenericElastic.hpp
@@ -67,7 +67,27 @@ namespace polyfem::assembler
 		virtual bool real_def_grad() const { return true; }
 
 	protected:
-		AutodiffType autodiff_type_ = AutodiffType::STRESS;
+
+	    AutodiffType autodiff_type_ = AutodiffType::STRESS;
+    	std::vector<double> power_values_;
+
+		void read_power(const int index, const json &params)
+		{
+    		if (power_values_.size() <= index)
+        		power_values_.resize(index + 1, 1.0);
+    		if (params.contains("power"))
+        		power_values_[index] = params["power"].get<double>();
+   	 		else
+        		power_values_[index] = 1.0;
+		}
+
+	    double get_power(const int el_id) const
+    	{
+        	if (power_values_.empty()) return 1.0;
+        	if (power_values_.size() == 1) return power_values_[0];
+        	if (el_id >= 0 && el_id < (int)power_values_.size()) return power_values_[el_id];
+        	return 1.0;
+    	}
 
 		virtual Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 3, 3> gradient(
 			const RowVectorNd &p,
@@ -127,7 +147,14 @@ namespace polyfem::assembler
 				const T val = derived().elastic_energy(data.vals.val.row(p), data.t, data.vals.element_id, def_grad);
 
 				energy += val * data.da(p);
+				
+
+
 			}
+
+			energy = pow(energy, get_power(data.vals.element_id));
+			std::cout << "element_id: " << data.vals.element_id << " power: " << get_power(data.vals.element_id) << " energy: " << energy << std::endl;
+
 			return energy;
 		}
 

--- a/src/polyfem/assembler/GenericElastic.hpp
+++ b/src/polyfem/assembler/GenericElastic.hpp
@@ -145,16 +145,10 @@ namespace polyfem::assembler
 				}
 
 				const T val = derived().elastic_energy(data.vals.val.row(p), data.t, data.vals.element_id, def_grad);
-
 				energy += val * data.da(p);
-				
-
-
 			}
 
 			energy = pow(energy, get_power(data.vals.element_id));
-			std::cout << "element_id: " << data.vals.element_id << " power: " << get_power(data.vals.element_id) << " energy: " << energy << std::endl;
-
 			return energy;
 		}
 

--- a/src/polyfem/assembler/GenericElastic.hpp
+++ b/src/polyfem/assembler/GenericElastic.hpp
@@ -69,25 +69,6 @@ namespace polyfem::assembler
 	protected:
 
 	    AutodiffType autodiff_type_ = AutodiffType::STRESS;
-    	std::vector<double> power_values_;
-
-		void read_power(const int index, const json &params)
-		{
-    		if (power_values_.size() <= index)
-        		power_values_.resize(index + 1, 1.0);
-    		if (params.contains("power"))
-        		power_values_[index] = params["power"].get<double>();
-   	 		else
-        		power_values_[index] = 1.0;
-		}
-
-	    double get_power(const int el_id) const
-    	{
-        	if (power_values_.empty()) return 1.0;
-        	if (power_values_.size() == 1) return power_values_[0];
-        	if (el_id >= 0 && el_id < (int)power_values_.size()) return power_values_[el_id];
-        	return 1.0;
-    	}
 
 		virtual Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 3, 3> gradient(
 			const RowVectorNd &p,
@@ -147,8 +128,6 @@ namespace polyfem::assembler
 				const T val = derived().elastic_energy(data.vals.val.row(p), data.t, data.vals.element_id, def_grad);
 				energy += val * data.da(p);
 			}
-
-			energy = pow(energy, get_power(data.vals.element_id));
 			return energy;
 		}
 

--- a/tests/test_assembler.cpp
+++ b/tests/test_assembler.cpp
@@ -340,52 +340,32 @@ TEST_CASE("amips_power_default", "[assembler]")
 
 TEST_CASE("amips_power_squared", "[assembler]")
 {
-    const std::string path = POLYFEM_DATA_DIR;
-    json in_args = json({});
-    in_args["geometry"] = {};
-    in_args["geometry"]["mesh"] = path + "/plane_hole.obj";
-    in_args["geometry"]["surface_selection"] = 7;
+	AMIPSEnergy base_amips, power2_amips;
+	base_amips.set_size(2);
+	power2_amips.set_size(2);
 
-    in_args["preset_problem"] = {};
-    in_args["preset_problem"]["type"] = "ElasticExact";
+	json params_base = {{"type", "AMIPS"}};
+	json params_power2 = {{"type", "AMIPS"}, {"power", 2.0}};
 
-    in_args["materials"] = {};
-    in_args["materials"]["type"] = "NeoHookean";
-    in_args["materials"]["E"] = 1e5;
-    in_args["materials"]["nu"] = 0.3;
+	Units units;
+	base_amips.add_multimaterial(0, params_base, units, "");
+	power2_amips.add_multimaterial(0, params_power2, units, "");
 
-    State state;
-    state.init_logger("", spdlog::level::err, spdlog::level::off, false);
-    state.init(in_args, true);
-    state.load_mesh();
-    state.build_basis();
 
-    AMIPSEnergy base_amips, power2_amips;
-    base_amips.set_size(2);
-    power2_amips.set_size(2);
 
-    json params_base = {{"type", "AMIPS"}};
-    json params_power2 = {{"type", "AMIPS"}, {"power", 2.0}};
+	Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 3, 3> F(2, 2);
+	F.setIdentity();
+	F(0, 0) = 1.1; F(0, 1) = 0.1;
+	F(1, 0) = 0.0; F(1, 1) = 0.9;
 
-    base_amips.add_multimaterial(0, params_base, state.units, state.root_path());
-    power2_amips.add_multimaterial(0, params_power2, state.units, state.root_path());
 
-    const int el_id = 0;
-    const auto &bs = state.bases[el_id];
-    ElementAssemblyValues vals;
-    vals.compute(el_id, false, bs, bs);
-    const QuadratureVector da = vals.det.array() * vals.quadrature.weights.array();
 
-    Eigen::MatrixXd displacement(state.n_bases, 1);
-    for (int rand = 0; rand < 10; ++rand)
-    {
-        displacement.setRandom();
-        const NonLinearAssemblerData data(vals, 0, 0, displacement, displacement, da);
-        const double e = base_amips.compute_energy(data);
-        const double e2 = power2_amips.compute_energy(data);
-        if (std::isnan(e))
-            REQUIRE(std::isnan(e2));
-        else
-            REQUIRE(e2 == Catch::Approx(e * e).margin(1e-12));
-    }
+	Eigen::RowVectorXd p = Eigen::RowVectorXd::Zero(2);
+
+	auto F1 = F;
+	auto F2 = F;
+	const double e = base_amips.elastic_energy<double>(p, 0, 0, F1);
+	const double e2 = power2_amips.elastic_energy<double>(p, 0, 0, F2);
+
+	REQUIRE(e2 == Catch::Approx(e * e).margin(1e-12));
 }

--- a/tests/test_assembler.cpp
+++ b/tests/test_assembler.cpp
@@ -3,6 +3,7 @@
 #include <polyfem/assembler/NeoHookeanElasticity.hpp>
 #include <polyfem/assembler/NeoHookeanElasticityAutodiff.hpp>
 
+#include <polyfem/assembler/AMIPSEnergy.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
@@ -283,4 +284,108 @@ TEST_CASE("generic_elastic_assembler", "[assembler]")
 			}
 		}
 	}
+}
+
+TEST_CASE("amips_power_default", "[assembler]")
+{
+    const std::string path = POLYFEM_DATA_DIR;
+    json in_args = json({});
+    in_args["geometry"] = {};
+    in_args["geometry"]["mesh"] = path + "/plane_hole.obj";
+    in_args["geometry"]["surface_selection"] = 7;
+
+    in_args["preset_problem"] = {};
+    in_args["preset_problem"]["type"] = "ElasticExact";
+
+    in_args["materials"] = {};
+    in_args["materials"]["type"] = "NeoHookean";
+    in_args["materials"]["E"] = 1e5;
+    in_args["materials"]["nu"] = 0.3;
+
+    State state;
+    state.init_logger("", spdlog::level::err, spdlog::level::off, false);
+    state.init(in_args, true);
+    state.load_mesh();
+    state.build_basis();
+
+    AMIPSEnergy no_power, with_power;
+    no_power.set_size(2);
+    with_power.set_size(2);
+
+    json params_no_power = {{"type", "AMIPS"}};
+    json params_with_power = {{"type", "AMIPS"}, {"power", 1.0}};
+
+    no_power.add_multimaterial(0, params_no_power, state.units, state.root_path());
+    with_power.add_multimaterial(0, params_with_power, state.units, state.root_path());
+
+    const int el_id = 0;
+    const auto &bs = state.bases[el_id];
+    ElementAssemblyValues vals;
+    vals.compute(el_id, false, bs, bs);
+    const QuadratureVector da = vals.det.array() * vals.quadrature.weights.array();
+
+    Eigen::MatrixXd displacement(state.n_bases, 1);
+    for (int rand = 0; rand < 10; ++rand)
+    {
+        displacement.setRandom();
+        const NonLinearAssemblerData data(vals, 0, 0, displacement, displacement, da);
+        const double e1 = no_power.compute_energy(data);
+        const double e2 = with_power.compute_energy(data);
+        if (std::isnan(e1))
+            REQUIRE(std::isnan(e2));
+        else
+            REQUIRE(e1 == Catch::Approx(e2).margin(1e-12));
+    }
+}
+
+TEST_CASE("amips_power_squared", "[assembler]")
+{
+    const std::string path = POLYFEM_DATA_DIR;
+    json in_args = json({});
+    in_args["geometry"] = {};
+    in_args["geometry"]["mesh"] = path + "/plane_hole.obj";
+    in_args["geometry"]["surface_selection"] = 7;
+
+    in_args["preset_problem"] = {};
+    in_args["preset_problem"]["type"] = "ElasticExact";
+
+    in_args["materials"] = {};
+    in_args["materials"]["type"] = "NeoHookean";
+    in_args["materials"]["E"] = 1e5;
+    in_args["materials"]["nu"] = 0.3;
+
+    State state;
+    state.init_logger("", spdlog::level::err, spdlog::level::off, false);
+    state.init(in_args, true);
+    state.load_mesh();
+    state.build_basis();
+
+    AMIPSEnergy base_amips, power2_amips;
+    base_amips.set_size(2);
+    power2_amips.set_size(2);
+
+    json params_base = {{"type", "AMIPS"}};
+    json params_power2 = {{"type", "AMIPS"}, {"power", 2.0}};
+
+    base_amips.add_multimaterial(0, params_base, state.units, state.root_path());
+    power2_amips.add_multimaterial(0, params_power2, state.units, state.root_path());
+
+    const int el_id = 0;
+    const auto &bs = state.bases[el_id];
+    ElementAssemblyValues vals;
+    vals.compute(el_id, false, bs, bs);
+    const QuadratureVector da = vals.det.array() * vals.quadrature.weights.array();
+
+    Eigen::MatrixXd displacement(state.n_bases, 1);
+    for (int rand = 0; rand < 10; ++rand)
+    {
+        displacement.setRandom();
+        const NonLinearAssemblerData data(vals, 0, 0, displacement, displacement, da);
+        const double e = base_amips.compute_energy(data);
+        const double e2 = power2_amips.compute_energy(data);
+        if (std::isnan(e))
+            REQUIRE(std::isnan(e2));
+        else
+            REQUIRE(e2 == Catch::Approx(e * e).margin(1e-12));
+    }
 }


### PR DESCRIPTION
This PR enables users to add a power to the AMIPS energy within the input JSON.

The following changes have been made:
1. Add a power attribute to the material json spec for AMIPS, and under material parameter including ID options
2. Add a function to GenericElastic class to read the power.
3. Add a getter to GenericElastic to get the power.
4. Add an additional step in energy computation under Generic Elastic to apply the power value. The value is 1 if not set.
5. Add a call in AMIPS energy class to get the power in the add_multimaterial() function
6. Added integration tests to test both default energy value when power not set, as well as energy when squared.