### PR TITLE
Revert catch2 ctest integration

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,4 +84,4 @@ include(Catch)
 
 # Register tests
 set(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS ON)
-catch_discover_tests(unit_tests)
+catch_discover_tests(unit_tests ADD_TAGS_AS_LABELS)


### PR DESCRIPTION

I accidentally removed `ADD_TAGS_AS_LABEL` in unrelated cleanup PR. Revert it.
