### PR TITLE
Fix/stiffness matrix and zero init

### DIFF
--- a/src/polyfem/assembler/Assembler.cpp
+++ b/src/polyfem/assembler/Assembler.cpp
@@ -347,23 +347,21 @@ namespace polyfem::assembler
 					long int offset = offsets[i];
 
 					std::copy(cache.entries().begin(), cache.entries().end(), triplets.begin() + offset);
-					offset += cache.entries().size();
+				offset += cache.entries().size();
 
-					if (cache.mat().nonZeros() > 0)
+				if (cache.mat().nonZeros() > 0)
+				{
+					long int count = 0;
+					for (int k = 0; k < cache.mat().outerSize(); ++k)
 					{
-						long int count = 0;
-						for (int k = 0; k < cache.mat().outerSize(); ++k)
+						for (StiffnessMatrix::InnerIterator it(cache.mat(), k); it; ++it)
 						{
-							for (Eigen::SparseMatrix<double>::InnerIterator it(cache.mat(), k); it; ++it)
-							{
-								assert(count < cache.mat().nonZeros());
-								triplets[offset + count++] = Eigen::Triplet<double>(it.row(), it.col(), it.value());
-							}
+							assert(count < cache.mat().nonZeros());
+							triplets[offset + count++] = Eigen::Triplet<double>(it.row(), it.col(), it.value());
 						}
 					}
-				});
-
-				timer.stop();
+				}
+			});				timer.stop();
 				logger().trace("done concatenate triplets {}s...", timer.getElapsedTime());
 
 				timer.start();

--- a/src/polyfem/mesh/remesh/L2Projection.cpp
+++ b/src/polyfem/mesh/remesh/L2Projection.cpp
@@ -15,8 +15,8 @@
 namespace polyfem::mesh
 {
 	Eigen::MatrixXd unconstrained_L2_projection(
-		const Eigen::SparseMatrix<double> &M,
-		const Eigen::SparseMatrix<double> &A,
+		const StiffnessMatrix &M,
+		const StiffnessMatrix &A,
 		const Eigen::Ref<const Eigen::MatrixXd> &y)
 	{
 		// Construct a linear solver for M
@@ -71,8 +71,8 @@ namespace polyfem::mesh
 		// Nonlinear solver
 		std::shared_ptr<polysolve::nonlinear::Solver> nl_solver,
 		// L2 projection form
-		const Eigen::SparseMatrix<double> &M,
-		const Eigen::SparseMatrix<double> &A,
+		const StiffnessMatrix &M,
+		const StiffnessMatrix &A,
 		const Eigen::VectorXd &y,
 		// Inversion-free form
 		const Eigen::MatrixXd &rest_positions,

--- a/src/polyfem/mesh/remesh/L2Projection.hpp
+++ b/src/polyfem/mesh/remesh/L2Projection.hpp
@@ -9,8 +9,8 @@
 namespace polyfem::mesh
 {
 	Eigen::MatrixXd unconstrained_L2_projection(
-		const Eigen::SparseMatrix<double> &M,
-		const Eigen::SparseMatrix<double> &A,
+		const StiffnessMatrix &M,
+		const StiffnessMatrix &A,
 		const Eigen::Ref<const Eigen::MatrixXd> &y);
 
 	void reduced_L2_projection(
@@ -24,8 +24,8 @@ namespace polyfem::mesh
 		// Nonlinear solver
 		std::shared_ptr<polysolve::nonlinear::Solver> nl_solver,
 		// L2 projection form
-		const Eigen::SparseMatrix<double> &M,
-		const Eigen::SparseMatrix<double> &A,
+		const StiffnessMatrix &M,
+		const StiffnessMatrix &A,
 		const Eigen::VectorXd &y,
 		// Inversion-free form
 		const Eigen::MatrixXd &rest_positions,

--- a/src/polyfem/mesh/remesh/Remesher.cpp
+++ b/src/polyfem/mesh/remesh/Remesher.cpp
@@ -139,7 +139,7 @@ namespace polyfem::mesh
 		// --------------------------------------------------------------------
 
 		// solve M x = A y for x where M is the mass matrix and A is the cross mass matrix.
-		Eigen::SparseMatrix<double> M, A;
+		StiffnessMatrix M, A;
 		{
 			MassMatrixAssembler assembler;
 			assembler::Mass mass_matrix_assembler;

--- a/src/polyfem/mesh/remesh/wild_remesh/LocalRelaxationData.hpp
+++ b/src/polyfem/mesh/remesh/wild_remesh/LocalRelaxationData.hpp
@@ -59,9 +59,7 @@ namespace polyfem::mesh
 
 		std::shared_ptr<assembler::Mass> mass_matrix_assembler;
 		assembler::AssemblyValsCache mass_assembly_vals_cache;
-		Eigen::SparseMatrix<double> mass;
-
-		std::shared_ptr<assembler::PressureAssembler> pressure_assembler;
+		StiffnessMatrix mass;		std::shared_ptr<assembler::PressureAssembler> pressure_assembler;
 
 		/// current problem, it contains rhs and bc
 		std::shared_ptr<assembler::Problem> problem;

--- a/src/polyfem/mesh/remesh/wild_remesh/Smooth.cpp
+++ b/src/polyfem/mesh/remesh/wild_remesh/Smooth.cpp
@@ -58,7 +58,7 @@ namespace polyfem::mesh
 		const Eigen::MatrixXd &to_projection_quantities = new_local_mesh.projection_quantities();
 
 		// solve M x = A y for x where M is the mass matrix and A is the cross mass matrix.
-		Eigen::SparseMatrix<double> M, A;
+		StiffnessMatrix M, A;
 		{
 			assembler::MassMatrixAssembler assembler;
 			assembler::Mass mass_matrix_assembler;

--- a/src/polyfem/solver/NLProblem.cpp
+++ b/src/polyfem/solver/NLProblem.cpp
@@ -665,7 +665,7 @@ namespace polyfem::solver
 			return full;
 		}
 
-		TVector reduced(reduced_size());
+		TVector reduced = TVector::Zero(reduced_size());
 		const TVector k = full - Q1R1iTb_;
 		const TVector rhs = Q2t_ * k;
 		solver_->solve(rhs, reduced);

--- a/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.cpp
+++ b/src/polyfem/solver/forms/lagrangian/BCLagrangianForm.cpp
@@ -3,6 +3,108 @@
 #include <polyfem/utils/Logger.hpp>
 #include <igl/slice.h>
 
+#ifdef POLYSOLVE_LARGE_INDEX
+#include <unordered_map>
+#include <cassert>
+#endif
+
+#ifdef POLYSOLVE_LARGE_INDEX
+namespace
+{
+	// Custom slice implementation for large indices
+	// Handles StiffnessMatrix with std::ptrdiff_t indices without converting to int
+	template <typename DerivedR>
+	void slice_stiffness_matrix(
+		const polyfem::StiffnessMatrix &X,
+		const Eigen::DenseBase<DerivedR> &R,
+		const int dim,
+		polyfem::StiffnessMatrix &Y)
+	{
+		using StorageIndex = std::ptrdiff_t;
+		
+		// Create a temporary result matrix to handle the case where X and Y are the same object
+		polyfem::StiffnessMatrix result;
+		
+		if (dim == 1) // Slice rows: Y = X(R, :)
+		{
+			const StorageIndex new_rows = R.size();
+			const StorageIndex new_cols = X.cols();
+			
+			std::vector<Eigen::Triplet<double, StorageIndex>> triplets;
+			triplets.reserve(X.nonZeros()); // Upper bound estimate
+			
+			// Create mapping from old row indices to new row indices (supports duplicate indices)
+			std::vector<std::vector<StorageIndex>> row_map;
+			row_map.resize(X.rows());
+			for (StorageIndex i = 0; i < new_rows; ++i)
+			{
+				const StorageIndex old_row = static_cast<StorageIndex>(R(i));
+				assert(old_row >= 0 && old_row < X.rows() && "Row index out of bounds");
+				row_map[old_row].push_back(i);
+			}
+			
+			// Iterate through all non-zero elements (outerSize() = cols for ColMajor)
+			for (StorageIndex k = 0; k < X.outerSize(); ++k)
+			{
+				for (typename polyfem::StiffnessMatrix::InnerIterator it(X, k); it; ++it)
+				{
+					for (const auto &new_row : row_map[it.row()])
+					{
+						triplets.emplace_back(new_row, it.col(), it.value());
+					}
+				}
+			}
+			
+			result.resize(new_rows, new_cols);
+			result.setFromTriplets(triplets.begin(), triplets.end());
+		}
+		else if (dim == 2) // Slice columns: Y = X(:, R)
+		{
+			const StorageIndex new_rows = X.rows();
+			const StorageIndex new_cols = R.size();
+			
+			std::vector<Eigen::Triplet<double, StorageIndex>> triplets;
+			triplets.reserve(X.nonZeros()); // Upper bound estimate
+			
+			// Create mapping from old column indices to new column indices (supports duplicate indices)
+			std::vector<std::vector<StorageIndex>> col_map;
+			col_map.resize(X.cols());
+			for (StorageIndex i = 0; i < new_cols; ++i)
+			{
+				const StorageIndex old_col = static_cast<StorageIndex>(R(i));
+				assert(old_col >= 0 && old_col < X.cols() && "Column index out of bounds");
+				col_map[old_col].push_back(i);
+			}
+			
+			// Iterate through all columns (outerSize() = cols for ColMajor)
+			for (StorageIndex k = 0; k < X.outerSize(); ++k)
+			{
+				if (!col_map[k].empty()) // Only process columns that are selected
+				{
+					for (typename polyfem::StiffnessMatrix::InnerIterator it(X, k); it; ++it)
+					{
+						for (const auto &new_col : col_map[k])
+						{
+							triplets.emplace_back(it.row(), new_col, it.value());
+						}
+					}
+				}
+			}
+			
+			result.resize(new_rows, new_cols);
+			result.setFromTriplets(triplets.begin(), triplets.end());
+		}
+		else
+		{
+			throw std::runtime_error("Invalid dimension for slice_stiffness_matrix (must be 1 or 2)");
+		}
+		
+		result.makeCompressed();
+		Y = std::move(result);
+	}
+}
+#endif
+
 namespace polyfem::solver
 {
 	BCLagrangianForm::BCLagrangianForm(const int ndof,
@@ -92,18 +194,22 @@ namespace polyfem::solver
 		if (obstacle_ndof != 0)
 		{
 			const int n_fe_dof = n_dofs_ - obstacle_ndof;
-			const double avg_mass = masked_lumped_mass_.diagonal().head(n_fe_dof).mean();
-			for (int i = n_fe_dof; i < n_dofs_; ++i)
-			{
-				masked_lumped_mass_.coeffRef(i, i) = avg_mass;
-			}
+		const double avg_mass = masked_lumped_mass_.diagonal().head(n_fe_dof).mean();
+		for (int i = n_fe_dof; i < n_dofs_; ++i)
+		{
+			masked_lumped_mass_.coeffRef(i, i) = avg_mass;
 		}
+	}
 
-		igl::slice(masked_lumped_mass_, constraints_, 1, masked_lumped_mass_);
-		igl::slice(masked_lumped_mass_, constraints_, 2, masked_lumped_mass_);
-		assert(boundary_nodes_.size() == masked_lumped_mass_.rows() && boundary_nodes_.size() == masked_lumped_mass_.cols());
-
-		masked_lumped_mass_sqrt_.resize(masked_lumped_mass_.rows(), masked_lumped_mass_.cols());
+#ifdef POLYSOLVE_LARGE_INDEX
+	slice_stiffness_matrix(masked_lumped_mass_, constraints_, 1, masked_lumped_mass_);
+	slice_stiffness_matrix(masked_lumped_mass_, constraints_, 2, masked_lumped_mass_);
+#else
+	igl::slice(masked_lumped_mass_, constraints_, 1, masked_lumped_mass_);
+	igl::slice(masked_lumped_mass_, constraints_, 2, masked_lumped_mass_);
+#endif
+	assert(boundary_nodes_.size() == masked_lumped_mass_.rows() && boundary_nodes_.size() == masked_lumped_mass_.cols());		
+	masked_lumped_mass_sqrt_.resize(masked_lumped_mass_.rows(), masked_lumped_mass_.cols());
 		std::vector<Eigen::Triplet<double>> tmp_triplets;
 		tmp_triplets.reserve(masked_lumped_mass_.nonZeros());
 		for (int k = 0; k < masked_lumped_mass_.outerSize(); ++k)

--- a/src/polyfem/utils/MatrixCache.hpp
+++ b/src/polyfem/utils/MatrixCache.hpp
@@ -108,8 +108,8 @@ namespace polyfem::utils
 		StiffnessMatrix tmp_, mat_;
 		std::vector<Eigen::Triplet<double>> entries_;              ///< contains global matrix indices and corresponding value
 		std::vector<std::vector<std::pair<int, size_t>>> mapping_; ///< maps row indices to column index/local index pairs
-		std::vector<int> inner_index_, outer_index_;               ///< saves inner/outer indices for sparse matrix
-		std::vector<double> values_;                               ///< buffer for values (corresponds to inner/outer_index_ structure for sparse matrix)
+		std::vector<StiffnessMatrix::StorageIndex> inner_index_, outer_index_; ///< saves inner/outer indices for sparse matrix
+		std::vector<double> values_; ///< buffer for values (corresponds to inner/outer_index_ structure for sparse matrix)
 		const SparseMatrixCache *main_cache_ = nullptr;
 
 		std::vector<std::vector<int>> second_cache_;                         ///< maps element index to local index


### PR DESCRIPTION
1. POLYSOLVE_LARGE_INDEX (64-bit index) support

With POLYSOLVE_LARGE_INDEX=ON, StiffnessMatrix uses 64-bit (std::ptrdiff_t) indices, but several spots hard-coded Eigen::SparseMatrix<double> (32-bit) or igl::slice (int-only), so that build didn't compile / could truncate indices. Fixes:

- Eigen::SparseMatrix<double> → StiffnessMatrix in the mass / L2-projection / remesh paths (Assembler.cpp, L2Projection.{cpp,hpp}, Remesher.cpp, Smooth.cpp, LocalRelaxationData.hpp).
- MatrixCache.hpp: index buffers use StiffnessMatrix::StorageIndex.
- BCLagrangianForm.cpp: under POLYSOLVE_LARGE_INDEX, igl::slice is replaced by a triplet-based slice_stiffness_matrix helper; default build keeps igl::slice.

All new paths are #ifdef POLYSOLVE_LARGE_INDEX-guarded, so the default 32-bit build is behaviorally unchanged.

2. Zero-initialize the reduced solver initial guess

src/polyfem/solver/NLProblem.cpp (full_to_reduced):

```
-        TVector reduced(reduced_size());
+        TVector reduced = TVector::Zero(reduced_size());
```

reduced is passed to solver_->solve(rhs, reduced) as the iterative solver's initial iterate $\mathbf{x}^{(0)}$ in $A,\mathbf{x} = \mathbf{rhs}$, but was uninitialized — heap garbage, sometimes NaN. That aborts the Hypre solve (INFs and/or NaNs detected in input) and throws Failed to apply constraints conditions... (ALSolver.cpp), ending in a core dump on large contact meshes: "Failed to apply constraints conditions; solve with augmented lagrangian first!"
